### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A comprehensive Model Context Protocol (MCP) server that integrates with the Scryfall API to provide Magic: The Gathering card data and functionality to AI assistants like Claude.
 
+<a href="https://glama.ai/mcp/servers/@bmurdock/scryfall-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@bmurdock/scryfall-mcp/badge" alt="Scryfall Server MCP server" />
+</a>
+
 ## Features
 
 ### 🔧 MCP Tools


### PR DESCRIPTION
This PR adds a badge for the [Scryfall MCP Server](https://glama.ai/mcp/servers/@bmurdock/scryfall-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@bmurdock/scryfall-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@bmurdock/scryfall-mcp/badge" alt="Scryfall Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.