### PR TITLE
[codex] Improve Scryfall throttling and Brawl deck tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,13 @@
 SCRYFALL_USER_AGENT=ScryfallMCPServer/1.0.2
 RATE_LIMIT_MS=100
+# Maximum number of queued Scryfall operations. Requests are paced globally.
+RATE_LIMIT_QUEUE_MAX=500
 LOG_LEVEL=info
 NODE_ENV=development
 SCRYFALL_TIMEOUT_MS=15000
 HEALTHCHECK_DEEP=false
-RATE_LIMIT_QUEUE_MAX=500
 CACHE_MAX_SIZE=10000
+# Large bulk resources are only retained when their serialized payload fits this cap.
 CACHE_MAX_MEMORY_MB=100
 HTTP_HOST=127.0.0.1
 HTTP_PORT=3000

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,8 @@ This repository is an MCP server for Scryfall-backed Magic: The Gathering workfl
 ## Performance Guardrails
 
 - For large cached payloads, avoid `JSON.stringify()` as a hot-path size estimator. Prefer explicit size hints or cheap approximate sizing.
+- Cache keys must include every input that can change returned data, ordering, pagination, or upstream request parameters.
+- Backoff and retry timing should have one owner. Avoid sleeping in both the failing request path and the next-request scheduling path.
 - Cache hits should avoid structural mutations unless a benchmark shows they are necessary.
 - If a heuristic assumes concurrency, verify it matches the actual scheduler and rate limiter.
 - For large remote JSON payloads, prefer streamed processing over full in-memory materialization when the response shape allows it.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ npm run dev:http
 npm run start:http
 ```
 
+For local MCP testing:
+
+```bash
+npm run dev:http:local
+npm run smoke:http
+```
+
+The smoke test checks `/health`, performs MCP `initialize`, sends `notifications/initialized`, and verifies `tools/list`.
+
 Current HTTP behavior:
 
 - binds to `127.0.0.1` by default

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ npm run smoke:http
 ```
 
 The smoke test checks `/health`, performs MCP `initialize`, sends `notifications/initialized`, and verifies `tools/list`.
+It also makes representative `validate_brawl_commander` and `search_cards` tool calls so the local HTTP endpoint is checked beyond discovery.
 
 Current HTTP behavior:
 
@@ -145,6 +146,14 @@ See [.env.example](./.env.example) for the canonical values. The main variables 
 - `HTTP_HEALTH_PATH`
 - `HTTP_ALLOWED_ORIGINS`
 
+Operational notes:
+
+- Scryfall API calls are globally serialized by the shared rate limiter. Batch tools may schedule multiple local lookups, but upstream Scryfall request completion remains one-at-a-time by design.
+- HTTP 429 responses are not retried automatically. The server records Scryfall's throttle window and delays the next request start so callers can decide whether to retry.
+- `CACHE_MAX_MEMORY_MB` controls whether large in-memory snapshots, including `card-database://bulk`, can be retained. Oversized bulk snapshots can still be returned for the current read, but metadata will report that they were not cached.
+- Deck-list analysis resolves card names exactly first, then falls back to fuzzy lookup for exact misses and reports any fuzzy resolutions in the response.
+- Deck-scale tools may return partial analysis or an explicit retry-after message when Scryfall throttles the underlying card lookups.
+
 Example local HTTP startup:
 
 ```bash
@@ -188,9 +197,12 @@ HTTP_HOST=127.0.0.1 HTTP_PORT=3000 npm run start:http
   "focus_card": "Obeka, Splitter of Seconds",
   "synergy_type": "theme",
   "format": "commander",
+  "color_identity": "UBR",
   "limit": 12
 }
 ```
+
+For commander-like workflows, pass `color_identity` when the focus is a theme rather than a resolvable card. When the focus resolves to a card, the tool infers that card's color identity and filters final results by requested legality, Arena availability, and color identity.
 
 ### `analyze_deck_composition`
 
@@ -228,6 +240,14 @@ Windows path: `%APPDATA%/Claude/claude_desktop_config.json`
 - The bulk card resource stores a pre-serialized snapshot to keep repeated reads cheap.
 - Set filtering is derived from one canonical cached `/sets` dataset to avoid incorrect filtered cache reuse.
 - Health checks are available through `ScryfallMCPServer.healthCheck()` and the HTTP `/health` endpoint.
+- If an MCP connector reports a JSON-RPC/SSE deserialization error, compare it against the raw HTTP smoke path:
+
+```bash
+npm run dev:http:local
+npm run smoke:http
+```
+
+If the smoke command succeeds, capture the connector error text and the smoke output together; that separates local endpoint framing from connector-specific parsing.
 
 ## Documentation Map
 

--- a/docs/decks/blech-loafing-pest-historic-brawl.md
+++ b/docs/decks/blech-loafing-pest-historic-brawl.md
@@ -1,0 +1,60 @@
+# Blech, Loafing Pest Historic Brawl Deck Test
+
+Date: 2026-04-27
+
+Commander: Blech, Loafing Pest
+Platform: Arena
+Format target: Historic Brawl, 100 cards, singleton except basic lands
+
+## Result
+
+The Arena import list is in `docs/decks/blech-loafing-pest-historic-brawl.txt`.
+
+The deck is BG lifegain counters midrange. Blech rewards life gain by putting +1/+1 counters on each Pest, Bat, Insect, Snake, and Spider, so the deck uses three overlapping packages:
+
+- Relevant creature types: Pest, Bat, Insect, Snake, and Spider bodies that scale with Blech.
+- Repeatable life gain: lifelink, Food, landfall life gain, High Market, The Shire, and drain effects.
+- Counter payoffs: Winding Constrictor, Inspiring Call, The Great Henge, Karn's Bastion, and large token boards from Scute Swarm, Arasta, Hornet Queen, Ishkanah, and Rotwidow Pack.
+
+## Tool Calls Used
+
+- `get_card` for `sos/176`.
+- `validate_brawl_commander` for `Blech, Loafing Pest` in `brawl`.
+- `find_synergistic_cards` for mechanic synergy.
+- `search_cards` with explicit `game:arena legal:brawl ci<=bg` filters for creature types, life gain, lifelink, Food, lands, draw/ramp, and removal.
+- `search_format_staples` for removal, ramp, and draw ideas.
+- `suggest_mana_base` for an initial BG mana base estimate.
+- `analyze_deck_composition` for a final pass, which failed because of rate limiting.
+
+## Issues Found
+
+1. `find_synergistic_cards` returned off-color cards for a BG commander.
+   - Repro: focus card `Blech, Loafing Pest`, format `brawl`, arena only, mechanic synergy.
+   - Example result: `Akroma's Will`, `Mangara, the Diplomat`, and `Danitha Capashen, Paragon`.
+   - Expected: tool should respect commander color identity or expose that it does not enforce deck-building constraints.
+
+2. `search_format_staples` does not appear to enforce Arena availability.
+   - Repro: format `brawl`, color identity `BG`, roles `removal`, `ramp`, and `draw`.
+   - Example results included Commander product print contexts such as `Neon Dynasty Commander` and `March of the Machine Commander`.
+   - Expected: either an `arena_only` option should be available for this tool, or Brawl staples should default to Arena-available cards when using `brawl` and `standardbrawl`.
+
+3. `suggest_mana_base` recommended 30 lands for a 100-card Brawl midrange deck.
+   - Repro: colors `BG`, deck size `100`, format `brawl`, strategy `midrange`, average CMC `3.2`.
+   - Expected: Historic Brawl recommendations should usually land closer to 36-40 lands, with adjustments for ramp and curve.
+
+4. `search_cards` query validation rejected valid Scryfall syntax containing `+1/+1`.
+   - Repro query: `game:arena legal:brawl ci<=bg (o:"put a +1/+1 counter" or o:proliferate)`.
+   - Error: `Query contains invalid characters. Only alphanumeric characters, spaces, and common search operators are allowed`.
+   - Expected: Scryfall oracle text queries need to allow plus signs and slash characters inside quoted strings.
+
+5. `analyze_deck_composition` failed with `Rate limit exceeded` after the deck-building search sequence.
+   - Repro: run the composition analyzer after several search and staple calls in one session.
+   - Expected: the tool should queue, delay, or return a structured retry hint instead of surfacing an unexpected error.
+
+## Validation Notes
+
+- `validate_brawl_commander` confirmed Blech is a valid Historic Brawl commander, BG color identity, Arena available, and legal.
+- The final list has 100 cards including commander.
+- The final list is singleton except for `Forest` and `Swamp`.
+- The final composition analyzer pass could not be completed because of the rate-limit issue above.
+- `npm test` passed after adding the deck artifacts: 21 test files and 236 tests passed.

--- a/docs/decks/blech-loafing-pest-historic-brawl.txt
+++ b/docs/decks/blech-loafing-pest-historic-brawl.txt
@@ -1,0 +1,98 @@
+Commander
+1 Blech, Loafing Pest
+
+Deck
+1 Gilded Goose
+1 Basilica Screecher
+1 Deep-Cavern Bat
+1 Starscape Cleric
+1 Kazandu Nectarpot
+1 Eumidian Terrabotanist
+1 Scute Swarm
+1 Springheart Nantuko
+1 Winding Constrictor
+1 Duskshell Crawler
+1 Pest Mascot
+1 Blex, Vexing Pest
+1 Mirkwood Bats
+1 Dina, Soul Steeper
+1 Blood Researcher
+1 Peregrin Took
+1 Tireless Provisioner
+1 Academy Manufactor
+1 Camellia, the Seedmiser
+1 Savvy Hunter
+1 Greta, Sweettooth Scourge
+1 Vito, Thorn of the Dusk Rose
+1 Marauding Blight-Priest
+1 Enduring Tenacity
+1 Aclazotz, Deepest Betrayal
+1 Arasta of the Endless Web
+1 Hornet Nest
+1 Hornet Queen
+1 Shelob, Child of Ungoliant
+1 Skyfisher Spider
+1 Rotwidow Pack
+1 Ishkanah, Grafwidow
+1 Hooded Blightfang
+1 Grist, Voracious Larva
+1 Glissa Sunslayer
+1 South Wind Avatar
+1 Sporeweb Weaver
+1 Shigeki, Jukai Visionary
+1 Basilisk Collar
+1 Shadowspear
+1 Whip of Erebos
+1 Sanguine Bond
+1 Exsanguinate
+1 The Meathook Massacre
+1 Inspiring Call
+1 Shamanic Revelation
+1 The Great Henge
+1 Guardian Project
+1 Phyrexian Arena
+1 Deadly Dispute
+1 Village Rites
+1 Cultivate
+1 Farseek
+1 Rampant Growth
+1 Arcane Signet
+1 Mind Stone
+1 Talisman of Resilience
+1 Many Partings
+1 Heaped Harvest
+1 Trail of Crumbs
+1 Assassin's Trophy
+1 Mortality Spear
+1 Feed the Swarm
+1 Go for the Throat
+1 Command Tower
+1 Overgrown Tomb
+1 Woodland Cemetery
+1 Deathcap Glade
+1 Necroblossom Snarl
+1 Llanowar Wastes
+1 Temple of Malady
+1 Darkbore Pathway
+1 Restless Cottage
+1 Jungle Hollow
+1 Haunted Mire
+1 Underground Mortuary
+1 Wastewood Verge
+1 Fabled Passage
+1 Evolving Wilds
+1 Terramorphic Expanse
+1 Riveteers Overlook
+1 Bojuka Bog
+1 Boseiju, Who Endures
+1 Takenuma, Abandoned Mire
+1 Karn's Bastion
+1 High Market
+1 The Shire
+1 Castle Garenbrig
+1 Castle Locthwain
+1 Bonders' Enclave
+1 Swarmyard
+1 Phyrexian Tower
+4 Forest
+3 Swamp

--- a/docs/decks/sanar-unfinished-genius-historic-brawl.md
+++ b/docs/decks/sanar-unfinished-genius-historic-brawl.md
@@ -1,0 +1,117 @@
+# Sanar, Unfinished Genius Historic Brawl
+
+Arena import block:
+
+```text
+Commander
+1 Sanar, Unfinished Genius (SOS) 223
+
+Deck
+1 Guttersnipe (FDN) 716
+1 Goblin Electromancer (GRN) 174
+1 Storm-Kiln Artist (STX) 115
+1 Archmage Emeritus (STX) 37
+1 Balmor, Battlemage Captain (FDN) 237
+1 Third Path Iconoclast (BRO) 223
+1 Young Pyromancer (JMP) 372
+1 Talrand, Sky Summoner (JMP) 181
+1 Murmuring Mystic (GRN) 45
+1 Erebor Flamesmith (LTR) 122
+1 Kaza, Roil Chaser (ZNR) 225
+1 Rootha, Mercurial Artist (STX) 227
+1 Prismari Apprentice (STX) 213
+1 Naru Meha, Master Wizard (DOM) 59
+1 Gandalf the Grey (LTR) 207
+1 Chrome Host Seedshark (MOM) 51
+1 Baral and Kari Zev (MOM) 218
+1 Baral, Chief of Compliance (MUL) 8
+1 Slickshot Show-Off (OTJ) 146
+1 Magmatic Channeler (ZNR) 148
+1 Witty Roastmaster (SNC) 131
+1 Ral, Storm Conduit (WAR) 211
+1 Ral, Crackling Wit (BLB) 230
+1 Saheeli, Sublime Artificer (WAR) 234
+1 Invasion of Segovia (MOM) 63
+1 Arcane Signet (ELD) 331
+1 Mind Stone (HA1) 19
+1 Coldsteel Heart (HA4) 22
+1 Midnight Clock (ELD) 54
+1 The Celestus (MID) 252
+1 Double Vision (M21) 142
+1 Thousand-Year Storm (FDN) 248
+1 Prismari Command (STX) 214
+1 Opt (FDN) 512
+1 Consider (MID) 44
+1 Sleight of Hand (WOE) 67
+1 Play with Fire (MID) 154
+1 Lightning Strike (TLA) 146
+1 Abrade (FDN) 188
+1 Fiery Impulse (EA2) 13
+1 Torch the Tower (WOE) 153
+1 Counterspell (OMB) 9
+1 Negate (TMT) 47
+1 Spell Pierce (DFT) 64
+1 Stern Scolding (LTR) 71
+1 Wash Away (VOW) 87
+1 Saw It Coming (KHM) 76
+1 Big Score (SNC) 102
+1 Unexpected Windfall (AFR) 164
+1 Seize the Spoils (SOS) 129
+1 Practical Research (STX) 212
+1 Teach by Example (FDN) 666
+1 Twinferno (DMU) 149
+1 Solve the Equation (STX) 54
+1 Experimental Augury (ONE) 49
+1 Quick Study (SOS) 65
+1 Thirst for Discovery (VOW) 85
+1 Radical Idea (GRN) 52
+1 Finale of Promise (WAR) 127
+1 Magma Opus (STX) 203
+1 Creative Outburst (STX) 171
+1 Command Tower (ELD) 333
+1 Reliquary Tower (M19) 254
+1 Riverglide Pathway (ZNR) 264
+1 Steam Vents (ECL) 267
+1 Spirebluff Canal (OTJ) 270
+1 Shivan Reef (DMU) 255
+1 Stormcarved Coast (SOS) 263
+1 Sulfur Falls (DOM) 247
+1 Thundering Falls (MKM) 269
+1 Fiery Islet (HA7) 21
+1 Frostboil Snarl (STX) 265
+1 Izzet Guildgate (FDN) 691
+1 Prismari Campus (STX) 270
+1 Swiftwater Cliffs (TDM) 268
+1 Temple of Epiphany (FDN) 699
+1 Volatile Fjord (KHM) 273
+1 Plaza of Heroes (DMU) 252
+1 Den of the Bugbear (AFR) 254
+1 Hall of Storm Giants (AFR) 257
+1 Otawara, Soaring City (NEO) 271
+1 Sokenzan, Crucible of Defiance (NEO) 276
+1 Castle Vantress (ELD) 242
+1 Castle Embereth (ELD) 239
+1 Mystic Sanctuary (ELD) 247
+1 Fabled Passage (BLB) 252
+1 Evolving Wilds (ECL) 264
+1 Field of Ruin (MID) 262
+1 Demolition Field (FDN) 687
+1 Mirrex (ONE) 254
+1 Restless Spire (WOE) 260
+5 Island (SOS) 274
+3 Mountain (SOS) 278
+```
+
+Validation notes:
+
+- Re-tested on 2026-04-28 through the local Streamable HTTP MCP endpoint at `http://127.0.0.1:3000/mcp`.
+- `npm run smoke:http` passed after restarting the stale detached `screen` listener from the current branch.
+- The commander was validated through MCP as legal for Historic Brawl and Arena available.
+- The deck contains 100 cards total: 1 commander plus 99 maindeck cards.
+- Chunked exact-name `search_cards` calls resolved all 94 unique card names under `game:arena legal:brawl`; the apparent misses were DFC/name-normalization cases (`Sanar, Unfinished Genius // Wild Idea`, `Invasion of Segovia // Caetus, Sea Tyrant of Segovia`, and `Riverglide Pathway // Lavaglide Pathway`).
+- The remediated JSON formatter now exposes `set`, `collector_number`, and `arena_id` where available.
+- `suggest_mana_base` now recommends 38 lands for 100-card Historic Brawl, matching this deck's 38-land structure.
+- Remaining tool issues observed during the second exercise:
+  - The in-app MCP client did not recover after the HTTP server restart and returned a Streamable HTTP JSON-RPC deserialization error until direct HTTP calls were used.
+  - `find_synergistic_cards` still returned no Sanar results because earlier zero-result semantic queries (`unfinished`, `genius`) counted as failures and opened the circuit breaker before oracle-derived fallback queries could be used.
+  - `analyze_deck_composition` still made enough per-card lookups to hit a retryable `Rate limit exceeded` response on the 100-card list.

--- a/docs/sanar-mcp-exercise-issues.md
+++ b/docs/sanar-mcp-exercise-issues.md
@@ -12,7 +12,6 @@ Exercise:
 Artifacts produced:
 
 - `docs/decks/sanar-unfinished-genius-historic-brawl.md`
-- Remediation plan: `docs/superpowers/plans/2026-04-28-sanar-mcp-exercise-remediation.md`
 
 ## Summary
 

--- a/docs/sanar-mcp-exercise-issues.md
+++ b/docs/sanar-mcp-exercise-issues.md
@@ -1,0 +1,142 @@
+# Sanar MCP Exercise Issues
+
+Date: 2026-04-28
+
+Exercise:
+
+- Start and verify `scryfall-http-local`.
+- Use the local Streamable HTTP MCP server to build an Arena-only Historic Brawl deck for `Sanar, Unfinished Genius // Wild Idea`.
+- Convert the recommendation into an Arena importable Markdown artifact.
+- Observe tool behavior, latency, and bugs during real use.
+
+Artifacts produced:
+
+- `docs/decks/sanar-unfinished-genius-historic-brawl.md`
+- Remediation plan: `docs/superpowers/plans/2026-04-28-sanar-mcp-exercise-remediation.md`
+
+## Summary
+
+The HTTP MCP server worked after manual startup and handled normal `initialize`, `tools/list`, `get_card`, `validate_brawl_commander`, and chunked `search_cards` flows. The exercise found several issues around operational readiness, newer-card synergy discovery, rate-limit behavior, deck-list parsing, Brawl land-count heuristics, and export data completeness.
+
+## Findings
+
+### 1. `scryfall-http-local` was registered but not running
+
+- Severity: medium
+- Status: resolved on 2026-04-28 by `docs: add HTTP MCP smoke workflow`
+- Evidence:
+  - Codex config had `[mcp_servers.scryfall-http-local] url = "http://127.0.0.1:3000/mcp"`.
+  - `curl http://127.0.0.1:3000/health` initially failed with connection refused.
+  - Starting `npm run dev:http` in the foreground brought the server up.
+  - Final operating state was a detached `screen` session named `scryfall-http-local`, with `/health` returning healthy.
+- Impact:
+  - A configured HTTP MCP server can appear available to clients while no listener exists.
+  - Users need manual command knowledge to recover.
+- Expected behavior:
+  - The repo should provide an explicit local HTTP startup/smoke workflow that verifies `/health`, MCP initialization, and `tools/list`.
+
+### 2. First background startup attempt did not stay running
+
+- Severity: low
+- Status: resolved on 2026-04-28 by `docs: add HTTP MCP smoke workflow`
+- Evidence:
+  - `nohup npm run dev:http > /tmp/scryfall-http-local.log 2>&1 &` returned a PID, but no listener appeared and the log remained empty.
+  - Foreground `npm run dev:http` and later a detached `screen` session worked.
+- Impact:
+  - The documented or recommended startup method needs to be robust for long-running local MCP testing.
+- Expected behavior:
+  - Local docs should recommend a command that stays attached or a tested detached command.
+
+### 3. `find_synergistic_cards` returned no results for Sanar
+
+- Severity: medium
+- Status: resolved on 2026-04-28 by `fix: derive synergy queries from oracle text`
+- Evidence:
+  - Call: `find_synergistic_cards` with `focus_card: "Sanar, Unfinished Genius"`, `synergy_type: "theme"`, `format: "brawl"`, `arena_only: true`, `limit: 20`.
+  - Result: `No synergistic cards found for "Sanar, Unfinished Genius" in brawl.`
+  - Follow-up direct MCP searches found many relevant cards for the same commander and constraints, including `Storm-Kiln Artist`, `Archmage Emeritus`, `Guttersnipe`, `Goblin Electromancer`, and `Third Path Iconoclast`.
+- Impact:
+  - Newer commanders with limited historical popularity can fail discovery even when obvious oracle-text synergies exist.
+- Expected behavior:
+  - If the focus card is found, the tool should derive fallback searches from oracle text, type line, color identity, and commander-relevant mechanics instead of returning empty.
+
+### 4. Rate-limit handling opened the circuit breaker and blocked later calls
+
+- Severity: high
+- Status: resolved on 2026-04-28 by `fix: keep 429 retry state out of circuit breaker`
+- Evidence:
+  - Sequential exact-card verification succeeded for 22 cards, then one call returned `Rate limit exceeded. Retry after 60s.`
+  - Later calls returned `Scryfall API error: Circuit breaker is open due to consecutive failures`.
+  - `analyze_deck_composition` later ran for about 70 seconds and returned `Unexpected error: Rate limit exceeded`.
+- Impact:
+  - A single user workflow can poison the in-process client for subsequent calls until restart or enough state is reset.
+  - Tools surface mixed error messages instead of a consistent retryable status.
+- Expected behavior:
+  - HTTP 429 should pause/resume or return a structured retry hint without counting twice toward circuit-breaker failure.
+  - The circuit breaker should distinguish upstream rate limiting from repeated hard failures.
+
+### 5. `analyze_deck_composition` splits valid card names on commas
+
+- Severity: high
+- Status: resolved on 2026-04-28 by `fix: parse Arena deck lists with comma card names`
+- Evidence:
+  - The parser uses `deckList.split(/[\n,]/)`.
+  - Deck entries such as `Baral, Chief of Compliance`, `Ral, Storm Conduit`, `Balmor, Battlemage Captain`, and `Otawara, Soaring City` are split into partial fuzzy lookups.
+  - Logs showed ambiguous Scryfall calls such as `cards/named?fuzzy=Baral` and `cards/named?fuzzy=Ral`.
+- Impact:
+  - Arena-format and normal Magic card names are parsed incorrectly.
+  - The tool generates extra Scryfall requests, increases ambiguity, and contributes to rate limiting.
+- Expected behavior:
+  - Newline-delimited deck lists should preserve commas inside card names.
+  - Arena import lines should parse quantities and strip optional `(SET) number` suffixes.
+
+### 6. `suggest_mana_base` recommends too few lands for 100-card Brawl
+
+- Severity: medium
+- Status: resolved on 2026-04-28 by `fix: tune Brawl mana base land counts`
+- Evidence:
+  - Call: `suggest_mana_base` with `deck_size: 100`, `format: "brawl"`, `strategy: "combo"`, `average_cmc: 2.7`.
+  - Result: `Total Lands: 30/100`.
+  - Source code clamps `format === "brawl"` to `22..26`, then a later global floor raises the result to only 30 for a 100-card deck.
+- Impact:
+  - The recommendation is not usable for Historic Brawl, where 36-40 lands is a common baseline depending on curve and ramp.
+- Expected behavior:
+  - Historic Brawl should use a 100-card land baseline similar to Commander, with separate handling for 60-card Standard Brawl if needed.
+
+### 7. `search_cards` JSON output omits set code and collector number
+
+- Severity: medium
+- Status: resolved on 2026-04-28 by `feat: expose card print identifiers`
+- Evidence:
+  - `formatCard()` includes `set_name`, but not Scryfall `set` or `collector_number`.
+  - Arena import output required lines such as `1 Sanar, Unfinished Genius (SOS) 223`.
+  - The final Markdown had to use direct Scryfall search responses for print identifiers after MCP legality/Arena validation.
+- Impact:
+  - The MCP tool cannot directly support Arena import-list generation even though the backing Scryfall data contains the fields.
+- Expected behavior:
+  - Formatted card JSON should include `set`, `collector_number`, and ideally `arena_id` when present.
+
+### 8. `search_cards` appends duplicate `game:arena`
+
+- Severity: low
+- Status: resolved on 2026-04-28 by `fix: avoid duplicate Arena search filters`
+- Evidence:
+  - When the input query already included `game:arena` and `arena_only: true` was set, logs showed final queries ending in `game:arena ... game:arena`.
+- Impact:
+  - This is harmless for Scryfall results but adds query noise and makes logs harder to read.
+- Expected behavior:
+  - The tool should append `game:arena` only if the sanitized query does not already contain a game filter that satisfies Arena availability.
+
+## What Worked Well
+
+- `validate_brawl_commander` correctly validated Sanar as Arena available and legal in Historic Brawl.
+- Chunked exact-name OR queries with `game:arena legal:brawl` worked reliably and kept request volume low.
+- Final validation resolved all 94 unique names in the import list.
+- The HTTP MCP handshake and `tools/list` were fast after startup.
+
+## Immediate Workaround Guidance
+
+- Prefer chunked `search_cards` OR queries over one MCP call per card when validating a deck list.
+- Avoid comma-separated input to `analyze_deck_composition` until the parser is fixed.
+- Restart the local HTTP server if a 429 opens the current in-process circuit breaker during testing.
+- For Arena import generation, use MCP validation plus direct Scryfall response fields until `FormattedCard` exposes `set` and `collector_number`.

--- a/package.json
+++ b/package.json
@@ -6,9 +6,11 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "dev:http": "tsx watch src/http.ts",
+    "dev:http:local": "HTTP_HOST=127.0.0.1 HTTP_PORT=3000 tsx src/http.ts",
     "build": "tsc && npm run test",
     "start": "node dist/index.js",
     "start:http": "node dist/http.js",
+    "smoke:http": "node scripts/smoke-http-mcp.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",

--- a/scripts/http-mcp-smoke-lib.mjs
+++ b/scripts/http-mcp-smoke-lib.mjs
@@ -1,0 +1,22 @@
+export function parseSseMessage(text) {
+  const lines = text.split(/\r?\n/);
+  const event = lines
+    .filter((line) => line.startsWith("event:"))
+    .map((line) => line.slice(6).trim())
+    .find(Boolean);
+
+  if (event !== "message") {
+    throw new Error(`Expected SSE event "message", got ${event || "none"}`);
+  }
+
+  const data = lines
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice(5).trim())
+    .join("\n");
+
+  if (!data) {
+    throw new Error("Expected SSE data payload");
+  }
+
+  return JSON.parse(data);
+}

--- a/scripts/smoke-http-mcp.mjs
+++ b/scripts/smoke-http-mcp.mjs
@@ -1,0 +1,88 @@
+const endpoint = process.env.MCP_HTTP_URL || "http://127.0.0.1:3000/mcp";
+const healthUrl = endpoint.replace(/\/mcp$/, "/health");
+
+let sessionId;
+let requestId = 1;
+
+function parseSse(text) {
+  const data = text
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice(5).trim())
+    .join("\n");
+
+  return data ? JSON.parse(data) : null;
+}
+
+async function postJsonRpc(payload) {
+  const headers = {
+    "Content-Type": "application/json",
+    Accept: "application/json, text/event-stream",
+  };
+
+  if (sessionId) {
+    headers["mcp-session-id"] = sessionId;
+  }
+
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload),
+  });
+
+  const returnedSessionId = response.headers.get("mcp-session-id");
+  if (returnedSessionId) {
+    sessionId = returnedSessionId;
+  }
+
+  if (response.status === 202) {
+    return null;
+  }
+
+  const text = await response.text();
+  const parsed = response.headers.get("content-type")?.includes("text/event-stream")
+    ? parseSse(text)
+    : JSON.parse(text);
+
+  if (!response.ok || parsed?.error) {
+    throw new Error(`MCP request failed: ${response.status} ${JSON.stringify(parsed?.error)}`);
+  }
+
+  return parsed.result;
+}
+
+const health = await fetch(healthUrl).then((response) => response.json());
+if (health.status !== "healthy") {
+  throw new Error(`Health check failed: ${JSON.stringify(health)}`);
+}
+
+const initialize = await postJsonRpc({
+  jsonrpc: "2.0",
+  id: requestId++,
+  method: "initialize",
+  params: {
+    protocolVersion: "2025-03-26",
+    capabilities: {},
+    clientInfo: { name: "scryfall-mcp-smoke", version: "0.1.0" },
+  },
+});
+
+await postJsonRpc({
+  jsonrpc: "2.0",
+  method: "notifications/initialized",
+});
+
+const tools = await postJsonRpc({
+  jsonrpc: "2.0",
+  id: requestId++,
+  method: "tools/list",
+  params: {},
+});
+
+console.log(JSON.stringify({
+  endpoint,
+  health: health.status,
+  server: initialize.serverInfo,
+  toolCount: tools.tools.length,
+  tools: tools.tools.map((tool) => tool.name),
+}, null, 2));

--- a/scripts/smoke-http-mcp.mjs
+++ b/scripts/smoke-http-mcp.mjs
@@ -1,18 +1,10 @@
+import { parseSseMessage } from "./http-mcp-smoke-lib.mjs";
+
 const endpoint = process.env.MCP_HTTP_URL || "http://127.0.0.1:3000/mcp";
 const healthUrl = endpoint.replace(/\/mcp$/, "/health");
 
 let sessionId;
 let requestId = 1;
-
-function parseSse(text) {
-  const data = text
-    .split(/\r?\n/)
-    .filter((line) => line.startsWith("data:"))
-    .map((line) => line.slice(5).trim())
-    .join("\n");
-
-  return data ? JSON.parse(data) : null;
-}
 
 async function postJsonRpc(payload) {
   const headers = {
@@ -41,7 +33,7 @@ async function postJsonRpc(payload) {
 
   const text = await response.text();
   const parsed = response.headers.get("content-type")?.includes("text/event-stream")
-    ? parseSse(text)
+    ? parseSseMessage(text)
     : JSON.parse(text);
 
   if (!response.ok || parsed?.error) {
@@ -79,10 +71,46 @@ const tools = await postJsonRpc({
   params: {},
 });
 
+const commanderValidation = await postJsonRpc({
+  jsonrpc: "2.0",
+  id: requestId++,
+  method: "tools/call",
+  params: {
+    name: "validate_brawl_commander",
+    arguments: {
+      card_identifier: "sos/223",
+      format: "brawl",
+    },
+  },
+});
+
+if (commanderValidation?.isError) {
+  throw new Error(`validate_brawl_commander failed: ${JSON.stringify(commanderValidation)}`);
+}
+
+const arenaSearch = await postJsonRpc({
+  jsonrpc: "2.0",
+  id: requestId++,
+  method: "tools/call",
+  params: {
+    name: "search_cards",
+    arguments: {
+      query: "Opt",
+      limit: 1,
+      arena_only: true,
+    },
+  },
+});
+
+if (arenaSearch?.isError) {
+  throw new Error(`search_cards failed: ${JSON.stringify(arenaSearch)}`);
+}
+
 console.log(JSON.stringify({
   endpoint,
   health: health.status,
   server: initialize.serverInfo,
   toolCount: tools.tools.length,
   tools: tools.tools.map((tool) => tool.name),
+  exercisedTools: ["validate_brawl_commander", "search_cards"],
 }, null, 2));

--- a/src/http.ts
+++ b/src/http.ts
@@ -142,8 +142,7 @@ async function createSessionTransport(
   const sdkServer = createSdkServer(MCP_SERVER_INFO);
   await appServer.setupHandlers(sdkServer);
 
-  let transport!: StreamableHTTPServerTransport;
-  transport = new StreamableHTTPServerTransport({
+  const transport = new StreamableHTTPServerTransport({
     sessionIdGenerator: () => randomUUID(),
     onsessioninitialized: (sessionId) => {
       sessionTransports.set(sessionId, { sdkServer, transport });

--- a/src/natural-language/query-builder/query-assembly.ts
+++ b/src/natural-language/query-builder/query-assembly.ts
@@ -1,5 +1,7 @@
 import { ConceptMapping } from '../types.js';
 
+const NUMERIC_OPERATORS = new Set(['cmc', 'pow', 'tou', 'usd', 'eur', 'tix']);
+
 export function buildBaseQuery(mappings: ConceptMapping[]): string {
   const queryParts: string[] = [];
   const grouped = groupMappingsByOperator(mappings);
@@ -28,14 +30,26 @@ function groupMappingsByOperator(mappings: ConceptMapping[]): Map<string, Concep
   return grouped;
 }
 
+export function formatQueryToken(
+  operator: string,
+  value: string,
+  comparison?: string,
+  negation = false
+): string {
+  const prefix = negation ? '-' : '';
+  const normalizedComparison = comparison === '=' ? '' : (comparison || '');
+  if (NUMERIC_OPERATORS.has(operator)) {
+    return `${prefix}${operator}${normalizedComparison}${value}`;
+  }
+  return `${prefix}${operator}:${normalizedComparison}${value}`;
+}
+
 function buildOperatorQuery(operator: string, mappings: ConceptMapping[]): string {
   if (mappings.length === 0) return '';
 
   if (mappings.length === 1) {
     const mapping = mappings[0];
-    const prefix = mapping.negation ? '-' : '';
-    const comparison = mapping.comparison || '';
-    return `${prefix}${operator}:${comparison}${mapping.value}`;
+    return formatQueryToken(operator, mapping.value, mapping.comparison, mapping.negation);
   }
 
   if (operator === 'o') {
@@ -48,38 +62,51 @@ function buildOperatorQuery(operator: string, mappings: ConceptMapping[]): strin
     return `(${values.map(value => `t:${value}`).join(' OR ')})`;
   }
 
-  if (['cmc', 'pow', 'tou', 'usd', 'eur', 'tix'].includes(operator)) {
+  if (NUMERIC_OPERATORS.has(operator)) {
     return buildNumericRange(operator, mappings);
   }
 
   const best = mappings.reduce((a, b) => (a.confidence > b.confidence ? a : b), mappings[0]);
-  const prefix = best.negation ? '-' : '';
-  const comparison = best.comparison || '';
-  return `${prefix}${operator}:${comparison}${best.value}`;
+  return formatQueryToken(operator, best.value, best.comparison, best.negation);
 }
 
 function buildNumericRange(operator: string, mappings: ConceptMapping[]): string {
-  const minMappings = mappings.filter(m => m.comparison === '>=' || m.comparison === '>');
-  const maxMappings = mappings.filter(m => m.comparison === '<=' || m.comparison === '<');
-  const exactMappings = mappings.filter(m => !m.comparison || m.comparison === '=');
+  let bestExact: ConceptMapping | null = null;
+  let bestMin: ConceptMapping | null = null;
+  let bestMax: ConceptMapping | null = null;
 
-  if (exactMappings.length > 0) {
-    const best = exactMappings.reduce((a, b) => (a.confidence > b.confidence ? a : b), exactMappings[0]);
-    return `${operator}:${best.value}`;
+  for (const mapping of mappings) {
+    if (!mapping.comparison || mapping.comparison === '=') {
+      if (!bestExact || mapping.confidence > bestExact.confidence) {
+        bestExact = mapping;
+      }
+      continue;
+    }
+
+    if (mapping.comparison === '>=' || mapping.comparison === '>') {
+      if (!bestMin || mapping.confidence > bestMin.confidence) {
+        bestMin = mapping;
+      }
+      continue;
+    }
+
+    if ((mapping.comparison === '<=' || mapping.comparison === '<') &&
+      (!bestMax || mapping.confidence > bestMax.confidence)) {
+      bestMax = mapping;
+    }
+  }
+
+  if (bestExact) {
+    return formatQueryToken(operator, bestExact.value, '=', bestExact.negation);
   }
 
   const parts: string[] = [];
-
-  if (minMappings.length > 0) {
-    const best = minMappings.reduce((a, b) => (a.confidence > b.confidence ? a : b), minMappings[0]);
-    parts.push(`${operator}:${best.comparison}${best.value}`);
+  if (bestMin) {
+    parts.push(formatQueryToken(operator, bestMin.value, bestMin.comparison, bestMin.negation));
   }
-
-  if (maxMappings.length > 0) {
-    const best = maxMappings.reduce((a, b) => (a.confidence > b.confidence ? a : b), maxMappings[0]);
-    parts.push(`${operator}:${best.comparison}${best.value}`);
+  if (bestMax) {
+    parts.push(formatQueryToken(operator, bestMax.value, bestMax.comparison, bestMax.negation));
   }
-
   return parts.join(' ');
 }
 

--- a/src/natural-language/query-builder/query-optimization.ts
+++ b/src/natural-language/query-builder/query-optimization.ts
@@ -1,6 +1,7 @@
 import { ScryfallClient } from '../../services/scryfall-client.js';
 import { mcpLogger } from '../../services/logger.js';
 import { BuildOptions, QueryOptimization, QueryTestSummary } from '../types.js';
+import { formatQueryToken } from './query-assembly.js';
 
 export interface TestedQuery {
   query: string;
@@ -30,9 +31,9 @@ function optimizeForPrecision(query: string): string {
     optimized += ' (f:standard OR f:modern OR f:commander)';
   }
 
-  const priceRegex = /(?:usd|eur|tix):/;
+  const priceRegex = /\b(?:usd|eur|tix)(?::|[<>]=?|=)/;
   if (!priceRegex.test(query)) {
-    optimized += ' usd<=50';
+    optimized += ` ${formatQueryToken('usd', '50', '<=')}`;
   }
 
   return optimized;
@@ -41,9 +42,9 @@ function optimizeForPrecision(query: string): string {
 function optimizeForRecall(query: string): string {
   let optimized = query;
 
-  optimized = optimized.replace(/pow:>=(\d+)/, (match, value) => {
+  optimized = optimized.replace(/\bpow(?::)?>=(\d+)/, (match, value) => {
     const newValue = Math.max(1, parseInt(value, 10) - 1);
-    return `pow:>=${newValue}`;
+    return formatQueryToken('pow', String(newValue), '>=');
   });
 
   optimized = optimized.replace(/t:(\w+)(?!\w)/, (match, type) => {
@@ -67,9 +68,9 @@ function optimizeForDiscovery(query: string): string {
 
 function optimizeForBudget(query: string): string {
   let optimized = query;
-  const budgetPriceRegex = /(?:usd|eur|tix):/;
+  const budgetPriceRegex = /\b(?:usd|eur|tix)(?::|[<>]=?|=)/;
   if (!budgetPriceRegex.test(query)) {
-    optimized += ' usd<=5';
+    optimized += ` ${formatQueryToken('usd', '5', '<=')}`;
   }
   return optimized;
 }
@@ -134,14 +135,16 @@ export async function testAndAdjustQuery(
 function broadenQuery(query: string): string {
   let broadened = query;
 
-  broadened = broadened.replace(/cmc:=(\d+)/, 'cmc<=$1');
-  broadened = broadened.replace(/pow:>=(\d+)/, (match, value) => {
-    const newValue = Math.max(1, parseInt(value, 10) - 1);
-    return `pow:>=${newValue}`;
+  broadened = broadened.replace(/\bcmc(?::)?=?(\d+)/, (_match, value) => {
+    return formatQueryToken('cmc', value, '<=');
   });
-  broadened = broadened.replace(/usd:<=(\d+)/, (match, value) => {
+  broadened = broadened.replace(/\bpow(?::)?>=(\d+)/, (match, value) => {
+    const newValue = Math.max(1, parseInt(value, 10) - 1);
+    return formatQueryToken('pow', String(newValue), '>=');
+  });
+  broadened = broadened.replace(/\busd(?::)?<=(\d+)/, (match, value) => {
     const newValue = parseInt(value, 10) * 2;
-    return `usd:<=${newValue}`;
+    return formatQueryToken('usd', String(newValue), '<=');
   });
 
   return broadened;
@@ -154,9 +157,9 @@ function narrowQuery(query: string): string {
     narrowed += ' f:modern';
   }
 
-  const narrowPriceRegex = /(?:usd|eur|tix):/;
+  const narrowPriceRegex = /\b(?:usd|eur|tix)(?::|[<>]=?|=)/;
   if (!narrowPriceRegex.test(query)) {
-    narrowed += ' usd<=20';
+    narrowed += ` ${formatQueryToken('usd', '20', '<=')}`;
   }
 
   return narrowed;

--- a/src/resources/card-database.ts
+++ b/src/resources/card-database.ts
@@ -12,6 +12,9 @@ type BulkSnapshotMetadata = {
 type BulkBuildDiagnostics = {
   totalCards: number;
   retainedChunks: number;
+  payloadBytes: number;
+  cached: boolean;
+  oversizeReason?: string;
 };
 
 const BULK_PAYLOAD_KEY = CacheService.createBulkKey('cards:serialized');
@@ -73,6 +76,8 @@ export class CardDatabaseResource {
   private lastBuildDiagnostics: BulkBuildDiagnostics = {
     totalCards: 0,
     retainedChunks: 0,
+    payloadBytes: 0,
+    cached: false,
   };
 
   constructor(
@@ -183,12 +188,39 @@ export class CardDatabaseResource {
       totalCards
     );
     const payload = finished.payload;
+    const payloadBytes = payload.length * 2;
+    const maxMemoryBytes = this.cache.getStats().maxMemoryBytes;
+
     this.lastBuildDiagnostics = {
       totalCards,
       retainedChunks: finished.chunks,
+      payloadBytes,
+      cached: false,
     };
 
-    this.cache.setWithType(BULK_PAYLOAD_KEY, payload, 'bulk_data', { sizeBytes: payload.length * 2 });
+    if (payloadBytes > maxMemoryBytes) {
+      const oversizeReason = `Payload size ${payloadBytes} bytes exceeds cache memory limit ${maxMemoryBytes} bytes`;
+      this.lastBuildDiagnostics = {
+        ...this.lastBuildDiagnostics,
+        oversizeReason,
+      };
+      mcpLogger.warn(
+        {
+          operation: 'bulk_snapshot_cache',
+          payloadBytes,
+          maxMemoryBytes,
+          totalCards,
+        },
+        'Bulk snapshot exceeds in-memory cache limit'
+      );
+    } else {
+      this.cache.setWithType(BULK_PAYLOAD_KEY, payload, 'bulk_data', { sizeBytes: payloadBytes });
+      this.lastBuildDiagnostics = {
+        ...this.lastBuildDiagnostics,
+        cached: this.cache.get<string>(BULK_PAYLOAD_KEY) === payload,
+      };
+    }
+
     this.cache.setWithType(BULK_METADATA_KEY, {
       updatedAt: oracleCards.updated_at,
       totalCards,
@@ -276,6 +308,7 @@ export class CardDatabaseResource {
       mimeType: this.mimeType,
       cache_stats: stats,
       cache_ttl_remaining: ttl,
+      last_build: this.lastBuildDiagnostics,
       last_update_check: new Date(this.lastUpdateCheck).toISOString(),
       next_update_check: new Date(this.lastUpdateCheck + this.updateCheckInterval).toISOString()
     };

--- a/src/services/cache-service.ts
+++ b/src/services/cache-service.ts
@@ -1,6 +1,18 @@
 import { CacheEntry, CACHE_DURATIONS } from '../types/mcp-types.js';
 import { EnvValidators } from '../utils/env-parser.js';
 
+export interface SearchCacheKeyParams {
+  query: string;
+  page?: number;
+  limit?: number;
+  unique?: string;
+  direction?: string;
+  include_multilingual?: boolean;
+  include_variations?: boolean;
+  include_extras?: boolean;
+  order?: string;
+}
+
 /**
  * In-memory cache service with TTL support and size limits
  */
@@ -64,6 +76,10 @@ export class CacheService {
 
     const entrySize = entry.sizeBytes ?? this.calculateEntrySize(key, entry);
     entry.sizeBytes = entrySize;
+
+    if (entrySize > this.maxMemoryBytes) {
+      return;
+    }
 
     // Remove existing entry if updating
     const existingEntry = this.cache.get(key);
@@ -279,35 +295,38 @@ export class CacheService {
   }
 
   /**
-   * Creates a cache key for search queries
+   * Creates a cache key for search queries.
+   *
+   * Cache identity must include every input that changes the upstream Scryfall
+   * search URL or returned result ordering. Build this from the normalized final
+   * request, not from raw tool input.
    */
-  static createSearchKey(
-    query: string,
+  static createSearchKey({
+    query,
     page = 1,
     limit = 20,
-    unique?: string,
-    direction?: string,
-    include_multilingual?: boolean,
-    include_variations?: boolean,
-    price_range?: { min?: number; max?: number; currency?: string }
-  ): string {
+    unique,
+    direction,
+    include_multilingual,
+    include_variations,
+    include_extras,
+    order,
+  }: SearchCacheKeyParams): string {
     const params = [query, page, limit];
     if (unique && unique !== 'cards') params.push(`unique:${unique}`);
     if (direction && direction !== 'auto') params.push(`dir:${direction}`);
     if (include_multilingual) params.push('multilingual');
     if (include_variations) params.push('variations');
-    if (price_range) {
-      const priceStr = `price:${price_range.min || 0}-${price_range.max || 'inf'}:${price_range.currency || 'usd'}`;
-      params.push(priceStr);
-    }
+    if (include_extras) params.push('extras');
+    if (order) params.push(`order:${order}`);
     return `search:${params.join(':')}`;
   }
 
   /**
    * Creates a cache key for card details
    */
-  static createCardKey(identifier: string, set?: string, lang = 'en'): string {
-    return `card:${identifier}:${set || 'any'}:${lang}`;
+  static createCardKey(identifier: string, set?: string, lang = 'en', match = 'fuzzy'): string {
+    return `card:${identifier}:${set || 'any'}:${lang}:${match}`;
   }
 
   /**
@@ -440,24 +459,21 @@ export class CacheService {
       return;
     }
 
-    const candidates = Array.from(this.cache.entries())
-      .map(([key, entry]) => ({
-        key,
-        entry,
-        accessTime: entry.lastAccessedAt ?? entry.timestamp,
-      }))
-      .sort((a, b) => a.accessTime - b.accessTime);
-
-    for (const { key, entry } of candidates) {
-      this.currentMemoryUsage -= this.getEntrySize(key, entry);
-      this.cache.delete(key);
-
-      if (
-        this.cache.size < this.maxSize &&
-        this.currentMemoryUsage + requiredBytes <= this.maxMemoryBytes
-      ) {
+    while (
+      this.cache.size > 0 &&
+      (this.cache.size >= this.maxSize || this.currentMemoryUsage + requiredBytes > this.maxMemoryBytes)
+    ) {
+      const key = this.findLeastRecentlyUsedKey();
+      if (!key) {
         break;
       }
+      const entry = this.cache.get(key);
+      if (!entry) {
+        break;
+      }
+
+      this.currentMemoryUsage -= this.getEntrySize(key, entry);
+      this.cache.delete(key);
     }
   }
 }

--- a/src/services/rate-limiter.ts
+++ b/src/services/rate-limiter.ts
@@ -114,13 +114,8 @@ export class RateLimiter {
   /**
    * Records an error for backoff calculation
    */
-  recordError(status?: number): void {
+  recordError(_status?: number): void {
     this.consecutiveErrors++;
-    
-    // Special handling for 429 (Too Many Requests)
-    if (status === 429) {
-      this.consecutiveErrors = Math.max(this.consecutiveErrors, 2);
-    }
   }
 
   /**
@@ -208,7 +203,9 @@ export class RateLimiter {
    * Handles 429 responses with Retry-After header
    */
   async handleRateLimitResponse(retryAfter?: string): Promise<void> {
-    this.recordError(429);
+    if (this.consecutiveErrors === 0) {
+      this.recordError(429);
+    }
 
     let delay = this.getCurrentBackoffDelay();
 

--- a/src/services/rate-limiter.ts
+++ b/src/services/rate-limiter.ts
@@ -6,6 +6,7 @@ interface QueuedRequest {
   resolve: (value?: unknown) => void;
   reject: (error: Error) => void;
   timestamp: number;
+  settled: boolean;
 }
 
 /**
@@ -19,6 +20,10 @@ export class RateLimiter {
   private consecutiveErrors = 0;
   private readonly maxQueueSize: number;
   private activeTimeouts = new Set<NodeJS.Timeout>();
+  private activeRequest: QueuedRequest | null = null;
+  private activeSleepReject: ((error: Error) => void) | null = null;
+  private resetGeneration = 0;
+  private nextAllowedRequestTime = 0;
 
   constructor(
     private minInterval: number = EnvValidators.rateLimitMs(process.env.RATE_LIMIT_MS),
@@ -41,11 +46,12 @@ export class RateLimiter {
         run: operation as () => Promise<unknown>,
         resolve: (value) => resolve(value as T),
         reject,
-        timestamp: Date.now()
+        timestamp: Date.now(),
+        settled: false
       });
 
       if (!this.processing) {
-        this.processQueue();
+        void this.processQueue();
       }
     });
   }
@@ -58,24 +64,36 @@ export class RateLimiter {
     if (this.processing) {
       return;
     }
-    
+
     this.processing = true;
+    const generation = this.resetGeneration;
 
     try {
-      while (this.queue.length > 0) {
+      while (this.queue.length > 0 && generation === this.resetGeneration) {
         const request = this.queue.shift()!;
-        
+        this.activeRequest = request;
+
         try {
           await this.enforceRateLimit();
           const result = await request.run();
-          request.resolve(result);
+          this.resolveRequest(request, result);
         } catch (error) {
-          request.reject(error instanceof Error ? error : new Error('Unknown rate limit error'));
+          this.rejectRequest(
+            request,
+            error instanceof Error ? error : new Error('Unknown rate limit error')
+          );
+        } finally {
+          if (this.activeRequest === request) {
+            this.activeRequest = null;
+          }
         }
       }
     } finally {
-      // Ensure processing flag is always reset
       this.processing = false;
+
+      if (this.queue.length > 0) {
+        void this.processQueue();
+      }
     }
   }
 
@@ -95,6 +113,7 @@ export class RateLimiter {
     
     // Calculate delay including exponential backoff for errors
     let delay = Math.max(0, this.minInterval - timeSinceLastRequest);
+    delay = Math.max(delay, this.nextAllowedRequestTime - now);
     
     if (this.consecutiveErrors > 0) {
       const backoffDelay = Math.min(
@@ -114,7 +133,11 @@ export class RateLimiter {
   /**
    * Records an error for backoff calculation
    */
-  recordError(_status?: number): void {
+  recordError(status?: number): void {
+    if (status !== undefined && status !== 429 && status < 500) {
+      return;
+    }
+
     this.consecutiveErrors++;
   }
 
@@ -155,13 +178,15 @@ export class RateLimiter {
     consecutiveErrors: number;
     currentBackoffDelay: number;
     lastRequestTime: number;
+    nextAllowedRequestTime: number;
   } {
     return {
       queueLength: this.queue.length,
       processing: this.processing,
       consecutiveErrors: this.consecutiveErrors,
       currentBackoffDelay: this.getCurrentBackoffDelay(),
-      lastRequestTime: this.lastRequestTime
+      lastRequestTime: this.lastRequestTime,
+      nextAllowedRequestTime: this.nextAllowedRequestTime
     };
   }
 
@@ -174,35 +199,75 @@ export class RateLimiter {
       clearTimeout(timeout);
     }
     this.activeTimeouts.clear();
-    
+
+    this.resetGeneration++;
+    const resetError = new RateLimitError('Rate limiter was reset');
+
+    if (this.activeSleepReject) {
+      this.activeSleepReject(resetError);
+      this.activeSleepReject = null;
+    }
+
+    if (this.activeRequest) {
+      this.rejectRequest(this.activeRequest, resetError);
+      this.activeRequest = null;
+    }
+
     // Reject all pending requests
     while (this.queue.length > 0) {
       const request = this.queue.shift()!;
-      request.reject(new RateLimitError('Rate limiter was reset'));
+      this.rejectRequest(request, resetError);
     }
-    
-    this.processing = false;
+
     this.consecutiveErrors = 0;
     this.lastRequestTime = 0;
+    this.nextAllowedRequestTime = 0;
   }
 
   /**
    * Utility method for sleeping with timeout tracking
    */
   private sleep(ms: number): Promise<void> {
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       const timeout = setTimeout(() => {
         this.activeTimeouts.delete(timeout);
+        if (this.activeSleepReject === activeReject) {
+          this.activeSleepReject = null;
+        }
         resolve();
       }, ms);
       this.activeTimeouts.add(timeout);
+
+      const activeReject = (error: Error) => {
+        clearTimeout(timeout);
+        this.activeTimeouts.delete(timeout);
+        reject(error);
+      };
+
+      this.activeSleepReject = activeReject;
     });
+  }
+
+  private resolveRequest(request: QueuedRequest, value?: unknown): void {
+    if (request.settled) {
+      return;
+    }
+    request.settled = true;
+    request.resolve(value);
+  }
+
+  private rejectRequest(request: QueuedRequest, error: Error): void {
+    if (request.settled) {
+      return;
+    }
+    request.settled = true;
+    request.reject(error);
   }
 
   /**
    * Handles 429 responses with Retry-After header
    */
-  async handleRateLimitResponse(retryAfter?: string): Promise<void> {
+  handleRateLimitResponse(retryAfter?: string): void {
     if (this.consecutiveErrors === 0) {
       this.recordError(429);
     }
@@ -216,9 +281,7 @@ export class RateLimiter {
       }
     }
 
-    if (delay > 0) {
-      await this.sleep(delay);
-    }
+    this.nextAllowedRequestTime = Math.max(this.nextAllowedRequestTime, Date.now() + delay);
   }
 
   /**
@@ -236,7 +299,8 @@ export class RateLimiter {
     const timeSinceLastRequest = now - this.lastRequestTime;
     const baseDelay = Math.max(0, this.minInterval - timeSinceLastRequest);
     const backoffDelay = this.getCurrentBackoffDelay();
+    const throttleDelay = Math.max(0, this.nextAllowedRequestTime - now);
     
-    return Math.max(baseDelay, backoffDelay);
+    return Math.max(baseDelay, backoffDelay, throttleDelay);
   }
 }

--- a/src/services/scryfall-client.ts
+++ b/src/services/scryfall-client.ts
@@ -22,14 +22,49 @@ export interface CardLookupParams {
   set?: string;
   lang?: string;
   face?: "front" | "back";
+  /**
+   * Use exact for known deck-list names. Use fuzzy for discovery-oriented
+   * user input. Cache and in-flight identity must include this mode.
+   */
+  match?: "fuzzy" | "exact";
+}
+
+interface SearchCardsParams {
+  query: string;
+  limit?: number;
+  page?: number;
+  include_extras?: boolean;
+  order?: string;
+  unique?: string;
+  direction?: string;
+  include_multilingual?: boolean;
+  include_variations?: boolean;
+  price_range?: {
+    min?: number;
+    max?: number;
+    currency?: string;
+  };
+}
+
+interface NormalizedSearchRequest {
+  query: string;
+  requestedPage: number;
+  requestedLimit: number;
+  include_extras?: boolean;
+  order?: string;
+  unique?: string;
+  direction?: string;
+  include_multilingual?: boolean;
+  include_variations?: boolean;
 }
 
 export function canonicalCardCacheKey(params: CardLookupParams): string {
   const canonicalIdentifier = params.identifier.trim().toLowerCase();
   const set = params.set?.trim().toLowerCase();
   const lang = params.lang?.trim().toLowerCase();
+  const match = params.match ?? "fuzzy";
 
-  return CacheService.createCardKey(canonicalIdentifier, set, lang || "en");
+  return CacheService.createCardKey(canonicalIdentifier, set, lang || "en", match);
 }
 
 /**
@@ -147,11 +182,13 @@ export class ScryfallClient {
     url: string,
     requestId: string
   ): Promise<ScryfallAPIError | RateLimitError> {
-    this.rateLimiter.recordError(response.status);
+    if (this.shouldRecordHttpError(response.status)) {
+      this.rateLimiter.recordError(response.status);
+    }
 
     if (response.status === 429) {
       const retryAfter = response.headers.get("retry-after");
-      await this.rateLimiter.handleRateLimitResponse(retryAfter || undefined);
+      this.rateLimiter.handleRateLimitResponse(retryAfter || undefined);
       const rateLimitError = new RateLimitError(
         "Rate limit exceeded",
         retryAfter ? parseInt(retryAfter, 10) : undefined
@@ -187,6 +224,10 @@ export class ScryfallClient {
       "Scryfall API error"
     );
     return apiError;
+  }
+
+  private shouldRecordHttpError(status: number): boolean {
+    return status === 429 || status >= 500;
   }
 
   private buildNetworkError(error: unknown, url: string, requestId: string): ScryfallAPIError {
@@ -233,40 +274,31 @@ export class ScryfallClient {
    * Searches for cards using Scryfall search syntax
    */
   async searchCards(
-    params: {
-      query: string;
-      limit?: number;
-      page?: number;
-      include_extras?: boolean;
-      order?: string;
-      unique?: string;
-      direction?: string;
-      include_multilingual?: boolean;
-      include_variations?: boolean;
-      price_range?: {
-        min?: number;
-        max?: number;
-        currency?: string;
-      };
-    },
+    params: SearchCardsParams,
     requestId?: string
   ): Promise<ScryfallSearchResponse> {
     const reqId = requestId || generateRequestId();
-    const requestedPage = params.page || 1;
-    const requestedLimit = params.limit || 20;
-    const cacheKey = CacheService.createSearchKey(
-      params.query,
-      requestedPage,
-      requestedLimit,
-      params.unique,
-      params.direction,
-      params.include_multilingual,
-      params.include_variations,
-      params.price_range
-    );
+    const searchRequest = this.normalizeSearchRequest(params);
+    const cacheKey = CacheService.createSearchKey({
+      query: searchRequest.query,
+      page: searchRequest.requestedPage,
+      limit: searchRequest.requestedLimit,
+      unique: searchRequest.unique,
+      direction: searchRequest.direction,
+      include_multilingual: searchRequest.include_multilingual,
+      include_variations: searchRequest.include_variations,
+      include_extras: searchRequest.include_extras,
+      order: searchRequest.order,
+    });
 
     mcpLogger.debug(
-      { requestId: reqId, operation: "search_cards", query: params.query, page: requestedPage, limit: requestedLimit },
+      {
+        requestId: reqId,
+        operation: "search_cards",
+        query: searchRequest.query,
+        page: searchRequest.requestedPage,
+        limit: searchRequest.requestedLimit,
+      },
       "Card search started"
     );
 
@@ -280,32 +312,23 @@ export class ScryfallClient {
       return cached;
     }
 
-    // Build query with price filtering if specified
-    let query = params.query;
-    if (params.price_range) {
-      const currency = params.price_range.currency || "usd";
-      if (params.price_range.min !== undefined) {
-        query += ` ${currency}>=${params.price_range.min}`;
-      }
-      if (params.price_range.max !== undefined) {
-        query += ` ${currency}<=${params.price_range.max}`;
-      }
-    }
-
-    const requestedOffset = (requestedPage - 1) * requestedLimit;
+    const requestedOffset = (searchRequest.requestedPage - 1) * searchRequest.requestedLimit;
     const startingApiPage = Math.floor(requestedOffset / this.searchApiPageSize) + 1;
     const relativeOffset = requestedOffset - ((startingApiPage - 1) * this.searchApiPageSize);
 
-    const firstPage = await this.fetchSearchPage(
-      {
-        ...params,
-        query,
-      },
-      startingApiPage,
-      reqId
-    );
+    const searchPageParams = {
+      query: searchRequest.query,
+      include_extras: searchRequest.include_extras,
+      order: searchRequest.order,
+      unique: searchRequest.unique,
+      direction: searchRequest.direction,
+      include_multilingual: searchRequest.include_multilingual,
+      include_variations: searchRequest.include_variations,
+    };
+
+    const firstPage = await this.fetchSearchPage(searchPageParams, startingApiPage, reqId);
     const totalCards = firstPage.total_cards ?? firstPage.data.length;
-    const requiredCount = Math.max(0, Math.min(requestedLimit, totalCards - requestedOffset));
+    const requiredCount = Math.max(0, Math.min(searchRequest.requestedLimit, totalCards - requestedOffset));
     let fetchedCards = firstPage.data.length;
     const collector = createSearchWindowCollector<ScryfallCard>(relativeOffset, requiredCount);
     collector.addPage(firstPage);
@@ -317,14 +340,7 @@ export class ScryfallClient {
       fetchedCards < relativeOffset + requiredCount &&
       currentPage.has_more
     ) {
-      currentPage = await this.fetchSearchPage(
-        {
-          ...params,
-          query,
-        },
-        nextApiPage,
-        reqId
-      );
+      currentPage = await this.fetchSearchPage(searchPageParams, nextApiPage, reqId);
       collector.addPage(currentPage);
       fetchedCards += currentPage.data.length;
       nextApiPage++;
@@ -347,6 +363,31 @@ export class ScryfallClient {
     );
 
     return data;
+  }
+
+  private normalizeSearchRequest(params: SearchCardsParams): NormalizedSearchRequest {
+    const queryParts = [params.query];
+    if (params.price_range) {
+      const currency = params.price_range.currency || "usd";
+      if (params.price_range.min !== undefined) {
+        queryParts.push(`${currency}>=${params.price_range.min}`);
+      }
+      if (params.price_range.max !== undefined) {
+        queryParts.push(`${currency}<=${params.price_range.max}`);
+      }
+    }
+
+    return {
+      query: queryParts.join(" "),
+      requestedPage: params.page || 1,
+      requestedLimit: params.limit || 20,
+      include_extras: params.include_extras,
+      order: params.order,
+      unique: params.unique,
+      direction: params.direction,
+      include_multilingual: params.include_multilingual,
+      include_variations: params.include_variations,
+    };
   }
 
   private async fetchSearchPage(
@@ -429,6 +470,7 @@ export class ScryfallClient {
       identifier: params.identifier.trim(),
       set: params.set?.trim().toLowerCase(),
       lang: params.lang?.trim().toLowerCase() || "en",
+      match: params.match ?? "fuzzy",
     };
   }
 
@@ -448,7 +490,7 @@ export class ScryfallClient {
     // Otherwise treat as card name
     else {
       url = new URL(`${this.baseUrl}/cards/named`);
-      url.searchParams.set("fuzzy", params.identifier);
+      url.searchParams.set(params.match === "exact" ? "exact" : "fuzzy", params.identifier);
       if (params.set) {
         url.searchParams.set("set", params.set);
       }

--- a/src/tools/analyze-deck-composition.ts
+++ b/src/tools/analyze-deck-composition.ts
@@ -1,21 +1,22 @@
 import { ScryfallClient } from '../services/scryfall-client.js';
-import { ValidationError } from '../types/mcp-types.js';
+import { RateLimitError, ValidationError } from '../types/mcp-types.js';
 import { Color, Rarity, ScryfallCard } from '../types/scryfall-api.js';
-import { normalizeLowercaseString, normalizeTrimmedString } from '../utils/input-normalization.js';
-import { fetchCardMapWithConcurrency } from './batch-card-analysis/fetcher.js';
+import { normalizeLowercaseString } from '../utils/input-normalization.js';
+import {
+  FetchCardsMapResult,
+  fetchCardMapWithDiagnostics,
+} from './batch-card-analysis/fetcher.js';
 
 interface AnalyzeDeckCompositionInput {
   deck_list: string;
   format?: string;
   strategy?: string;
-  commander?: string;
 }
 
 interface DeckAnalysisParams {
   deck_list: string;
   format?: string;
   strategy: string;
-  commander?: string;
 }
 
 export interface DeckCardEntry {
@@ -38,7 +39,13 @@ interface DeckCompositionAnalysis {
   averageCMC: number;
   expensiveCards: PriceEntry[];
   keyCards: string[];
-  problems: string[];
+}
+
+interface DeckFetchWarnings {
+  rateLimitError?: RateLimitError;
+  analyzedCardNames: number;
+  totalCardNames: number;
+  fuzzyResolutions: FetchCardsMapResult['fuzzyResolutions'];
 }
 
 function getExpectedLandCount(format: string | undefined, totalCards: number): number {
@@ -103,10 +110,6 @@ export class AnalyzeDeckCompositionTool {
         enum: ['aggro', 'midrange', 'control', 'combo', 'ramp', 'tribal', 'unknown'],
         default: 'unknown',
         description: 'Deck strategy archetype'
-      },
-      commander: {
-        type: 'string',
-        description: 'Commander card name (for Commander/Brawl formats)'
       }
     },
     required: ['deck_list']
@@ -125,7 +128,6 @@ export class AnalyzeDeckCompositionTool {
     const params = args as AnalyzeDeckCompositionInput;
     const normalizedFormat = normalizeLowercaseString(params.format);
     const normalizedStrategy = normalizeLowercaseString(params.strategy);
-    const normalizedCommander = normalizeTrimmedString(params.commander);
 
     if (!params.deck_list || typeof params.deck_list !== 'string') {
       throw new ValidationError('Deck list is required and must be a string');
@@ -147,8 +149,7 @@ export class AnalyzeDeckCompositionTool {
     return {
       deck_list: params.deck_list.trim(),
       format: typeof normalizedFormat === 'string' ? normalizedFormat : undefined,
-      strategy,
-      commander: typeof normalizedCommander === 'string' ? normalizedCommander : undefined
+      strategy
     };
   }
 
@@ -170,7 +171,22 @@ export class AnalyzeDeckCompositionTool {
       }
 
       // Fetch card data
-      const cardData = await this.fetchCardData(deckEntries);
+      const fetchResult = await this.fetchCardData(deckEntries);
+      const cardData = fetchResult.cards;
+
+      if (fetchResult.fatalError) {
+        throw fetchResult.fatalError;
+      }
+
+      if (fetchResult.rateLimitError && cardData.size === 0) {
+        return {
+          content: [{
+            type: 'text',
+            text: this.formatRateLimitFailure(fetchResult.rateLimitError)
+          }],
+          isError: true
+        };
+      }
       
       if (cardData.size === 0) {
         return {
@@ -189,7 +205,12 @@ export class AnalyzeDeckCompositionTool {
       const recommendations = this.generateRecommendations(analysis, params);
       
       // Format response
-      const responseText = this.formatAnalysisResponse(analysis, recommendations, params);
+      const responseText = this.formatAnalysisResponse(analysis, recommendations, params, {
+        rateLimitError: fetchResult.rateLimitError,
+        analyzedCardNames: cardData.size,
+        totalCardNames: deckEntries.length,
+        fuzzyResolutions: fetchResult.fuzzyResolutions,
+      });
       
       return {
         content: [{
@@ -229,12 +250,17 @@ export class AnalyzeDeckCompositionTool {
   /**
    * Fetch card data for all cards in the deck
    */
-  private async fetchCardData(deckEntries: DeckCardEntry[]): Promise<Map<string, ScryfallCard>> {
-    return fetchCardMapWithConcurrency(
+  private async fetchCardData(deckEntries: DeckCardEntry[]): Promise<FetchCardsMapResult> {
+    return fetchCardMapWithDiagnostics(
       this.scryfallClient,
       deckEntries.map(({ name }) => name),
-      { skipNotFound: true }
+      { skipNotFound: true, match: 'exact', fallbackToFuzzy: true }
     );
+  }
+
+  private formatRateLimitFailure(error: RateLimitError): string {
+    const retry = error.retryAfter ? ` Retry after ${error.retryAfter}s.` : '';
+    return `Rate limit exceeded.${retry} No deck analysis was produced.`;
   }
 
   /**
@@ -249,8 +275,7 @@ export class AnalyzeDeckCompositionTool {
       rarityBreakdown: {},
       averageCMC: 0,
       expensiveCards: [],
-      keyCards: [],
-      problems: []
+      keyCards: []
     };
 
     let totalCMC = 0;
@@ -370,9 +395,29 @@ export class AnalyzeDeckCompositionTool {
   private formatAnalysisResponse(
     analysis: DeckCompositionAnalysis,
     recommendations: string[],
-    params: DeckAnalysisParams
+    params: DeckAnalysisParams,
+    warnings?: DeckFetchWarnings
   ): string {
     let response = `**Deck Composition Analysis**\n\n`;
+
+    if (warnings?.rateLimitError) {
+      const retry = warnings.rateLimitError.retryAfter ? ` Retry after ${warnings.rateLimitError.retryAfter}s.` : '';
+      const missed = Math.max(0, warnings.totalCardNames - warnings.analyzedCardNames);
+      response += `⚠️ **Partial analysis:** Rate limit exceeded.${retry} `;
+      response += `${missed} card name${missed === 1 ? '' : 's'} `;
+      response += `${missed === 1 ? 'was' : 'were'} not analyzed.\n\n`;
+    }
+
+    if (warnings?.fuzzyResolutions.length) {
+      response += `ℹ️ **Fuzzy name resolutions:**\n`;
+      for (const resolution of warnings.fuzzyResolutions.slice(0, 10)) {
+        response += `• ${resolution.requestedName} -> ${resolution.resolvedName}\n`;
+      }
+      if (warnings.fuzzyResolutions.length > 10) {
+        response += `• ${warnings.fuzzyResolutions.length - 10} more\n`;
+      }
+      response += '\n';
+    }
     
     // Basic stats
     response += `📊 **Overview:**\n`;

--- a/src/tools/analyze-deck-composition.ts
+++ b/src/tools/analyze-deck-composition.ts
@@ -18,7 +18,7 @@ interface DeckAnalysisParams {
   commander?: string;
 }
 
-interface DeckCardEntry {
+export interface DeckCardEntry {
   name: string;
   quantity: number;
 }
@@ -39,6 +39,44 @@ interface DeckCompositionAnalysis {
   expensiveCards: PriceEntry[];
   keyCards: string[];
   problems: string[];
+}
+
+function getExpectedLandCount(format: string | undefined, totalCards: number): number {
+  if (format === 'commander') {
+    return 37;
+  }
+
+  if (format === 'brawl' && totalCards >= 90) {
+    return 38;
+  }
+
+  return 24;
+}
+
+export function parseDeckListEntries(deckList: string): DeckCardEntry[] {
+  const quantities = new Map<string, number>();
+
+  for (const rawLine of deckList.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line === 'Commander' || line === 'Deck') {
+      continue;
+    }
+
+    const match = line.match(/^(?:(\d+)x?\s+)?(.+?)(?:\s+\([A-Z0-9]+\)\s+[A-Za-z0-9]+)?$/i);
+    if (!match) {
+      continue;
+    }
+
+    const quantity = match[1] ? parseInt(match[1], 10) : 1;
+    const cardName = match[2].trim();
+    if (!cardName) {
+      continue;
+    }
+
+    quantities.set(cardName, (quantities.get(cardName) || 0) + quantity);
+  }
+
+  return Array.from(quantities.entries()).map(([name, quantity]) => ({ name, quantity }));
 }
 
 /**
@@ -185,24 +223,7 @@ export class AnalyzeDeckCompositionTool {
    * Parse deck list into individual card names
    */
   private parseDeckList(deckList: string): DeckCardEntry[] {
-    const lines = deckList.split(/[\n,]/).map(line => line.trim());
-    const quantities = new Map<string, number>();
-    
-    for (const line of lines) {
-      if (!line) continue;
-      
-      // Handle various formats: "4 Lightning Bolt", "Lightning Bolt", "4x Lightning Bolt"
-      const match = line.match(/^(?:(\d+)x?\s+)?(.+)$/i);
-      if (match) {
-        const quantity = match[1] ? parseInt(match[1], 10) : 1;
-        const cardName = match[2].trim();
-        if (cardName) {
-          quantities.set(cardName, (quantities.get(cardName) || 0) + quantity);
-        }
-      }
-    }
-    
-    return Array.from(quantities.entries()).map(([name, quantity]) => ({ name, quantity }));
+    return parseDeckListEntries(deckList);
   }
 
   /**
@@ -310,7 +331,7 @@ export class AnalyzeDeckCompositionTool {
     
     // Land count recommendations
     const landCount = analysis.typeBreakdown.lands || 0;
-    const expectedLands = format === 'commander' ? 37 : format === 'brawl' ? 24 : 24;
+    const expectedLands = getExpectedLandCount(format, analysis.totalCards);
     
     if (landCount < expectedLands - 2) {
       recommendations.push(`🌍 Consider adding ${expectedLands - landCount} more lands`);

--- a/src/tools/batch-card-analysis/fetcher.ts
+++ b/src/tools/batch-card-analysis/fetcher.ts
@@ -1,16 +1,119 @@
 import { ScryfallClient } from '../../services/scryfall-client.js';
-import { ScryfallAPIError, ValidationError } from '../../types/mcp-types.js';
+import { RateLimitError, ScryfallAPIError, ValidationError } from '../../types/mcp-types.js';
 import { ScryfallCard } from '../../types/scryfall-api.js';
 
+// This bounds helper-level scheduling for injected clients. The production
+// ScryfallClient still serializes upstream Scryfall request completion through
+// its global RateLimiter.
 const DEFAULT_CONCURRENCY = 4;
 
 interface FetchCardsMapOptions {
   concurrency?: number;
   skipNotFound?: boolean;
+  match?: 'fuzzy' | 'exact';
+  fallbackToFuzzy?: boolean;
+}
+
+export interface FuzzyCardResolution {
+  requestedName: string;
+  resolvedName: string;
+}
+
+export interface FetchCardsMapResult {
+  cards: Map<string, ScryfallCard>;
+  notFound: string[];
+  fuzzyResolutions: FuzzyCardResolution[];
+  rateLimitError?: RateLimitError;
+  fatalError?: unknown;
+  attempted: number;
 }
 
 export function uniqueInOrder(values: string[]): string[] {
   return Array.from(new Set(values));
+}
+
+export async function fetchCardMapWithDiagnostics(
+  scryfallClient: ScryfallClient,
+  cardList: string[],
+  options: FetchCardsMapOptions = {}
+): Promise<FetchCardsMapResult> {
+  const cards = new Map<string, ScryfallCard>();
+  const notFound: string[] = [];
+  const fuzzyResolutions: FuzzyCardResolution[] = [];
+  let nextIndex = 0;
+  let attempted = 0;
+  let stopped = false;
+  let rateLimitError: RateLimitError | undefined;
+  let fatalError: unknown;
+  const concurrency = options.concurrency ?? DEFAULT_CONCURRENCY;
+  const match = options.match ?? 'fuzzy';
+
+  const workerCount = Math.min(Math.max(1, concurrency), cardList.length);
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (!stopped && nextIndex < cardList.length) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      attempted += 1;
+      const cardName = cardList[currentIndex];
+
+      try {
+        const lookupParams = match === 'exact'
+          ? { identifier: cardName, match }
+          : { identifier: cardName };
+        const card = await scryfallClient.getCard(lookupParams);
+        cards.set(cardName, card);
+      } catch (error) {
+        if (error instanceof ScryfallAPIError && error.status === 404) {
+          if (match === 'exact' && options.fallbackToFuzzy) {
+            try {
+              const fuzzyCard = await scryfallClient.getCard({ identifier: cardName });
+              cards.set(cardName, fuzzyCard);
+              fuzzyResolutions.push({
+                requestedName: cardName,
+                resolvedName: fuzzyCard.name,
+              });
+              continue;
+            } catch (fallbackError) {
+              if (fallbackError instanceof ScryfallAPIError && fallbackError.status === 404) {
+                notFound.push(cardName);
+                continue;
+              }
+
+              if (fallbackError instanceof RateLimitError) {
+                rateLimitError = fallbackError;
+              } else {
+                fatalError = fallbackError;
+              }
+              stopped = true;
+              break;
+            }
+          }
+
+          notFound.push(cardName);
+          continue;
+        }
+
+        if (error instanceof RateLimitError) {
+          rateLimitError = error;
+        } else {
+          fatalError = error;
+        }
+        stopped = true;
+        break;
+      }
+    }
+  });
+
+  await Promise.all(workers);
+
+  return {
+    cards,
+    notFound,
+    fuzzyResolutions,
+    rateLimitError,
+    fatalError,
+    attempted,
+  };
 }
 
 export async function fetchCardMapWithConcurrency(
@@ -18,33 +121,17 @@ export async function fetchCardMapWithConcurrency(
   cardList: string[],
   options: FetchCardsMapOptions = {}
 ): Promise<Map<string, ScryfallCard>> {
-  const cards = new Map<string, ScryfallCard>();
-  const notFound: string[] = [];
-  let nextIndex = 0;
-  const concurrency = options.concurrency ?? DEFAULT_CONCURRENCY;
+  const result = await fetchCardMapWithDiagnostics(scryfallClient, cardList, options);
 
-  const workerCount = Math.min(Math.max(1, concurrency), cardList.length);
-  const workers = Array.from({ length: workerCount }, async () => {
-    while (nextIndex < cardList.length) {
-      const currentIndex = nextIndex;
-      nextIndex += 1;
-      const cardName = cardList[currentIndex];
+  if (result.rateLimitError) {
+    throw result.rateLimitError;
+  }
 
-      try {
-        const card = await scryfallClient.getCard({ identifier: cardName });
-        cards.set(cardName, card);
-      } catch (error) {
-        if (error instanceof ScryfallAPIError && error.status === 404) {
-          notFound.push(cardName);
-          continue;
-        }
+  if (result.fatalError) {
+    throw result.fatalError;
+  }
 
-        throw error;
-      }
-    }
-  });
-
-  await Promise.all(workers);
+  const { cards, notFound } = result;
 
   if (notFound.length > 0 && !options.skipNotFound) {
     throw new ValidationError(`Cards not found: ${notFound.join(', ')}`);

--- a/src/tools/find-synergistic-cards.ts
+++ b/src/tools/find-synergistic-cards.ts
@@ -1,9 +1,12 @@
 import { ScryfallClient } from '../services/scryfall-client.js';
 import { ValidationError, ScryfallAPIError } from '../types/mcp-types.js';
+import { MagicFormat, ScryfallCard } from '../types/scryfall-api.js';
 import { normalizeLowercaseString, normalizeTrimmedString } from '../utils/input-normalization.js';
 import {
+  buildBaseQuery,
   buildSynergyQueries,
-  getFallbackQueries
+  getFallbackQueries,
+  normalizeColorIdentity
 } from './find-synergistic-cards/query-builder.js';
 import {
   filterAndDeduplicateResults,
@@ -18,6 +21,18 @@ import {
 
 const MAX_PRIMARY_QUERY_CANDIDATES = 15;
 const MAX_FALLBACK_QUERY_CANDIDATES = 6;
+
+interface ValidatedSynergyParams {
+  focus_card: string;
+  synergy_type?: string;
+  format?: MagicFormat;
+  exclude_colors?: string;
+  max_cmc?: number;
+  include_lands: boolean;
+  limit: number;
+  arena_only: boolean;
+  color_identity?: string;
+}
 
 /**
  * MCP Tool for finding cards that synergize with a specific card, theme, or archetype
@@ -68,6 +83,10 @@ export class FindSynergisticCardsTool {
         type: 'boolean',
         default: false,
         description: 'Only return cards available in Arena'
+      },
+      color_identity: {
+        type: 'string',
+        description: 'Restrict results to this color identity (for example "UR", "Izzet", or "blue red")'
       }
     },
     required: ['focus_card']
@@ -78,16 +97,7 @@ export class FindSynergisticCardsTool {
   /**
    * Validate parameters
    */
-  private validateParams(args: unknown): {
-    focus_card: string;
-    synergy_type?: string;
-    format?: string;
-    exclude_colors?: string;
-    max_cmc?: number;
-    include_lands: boolean;
-    limit: number;
-    arena_only: boolean;
-  } {
+  private validateParams(args: unknown): ValidatedSynergyParams {
     if (!args || typeof args !== 'object') {
       throw new ValidationError('Invalid parameters');
     }
@@ -97,6 +107,7 @@ export class FindSynergisticCardsTool {
     const normalizedSynergyType = normalizeLowercaseString(params.synergy_type);
     const normalizedFormat = normalizeLowercaseString(params.format);
     const normalizedExcludeColors = normalizeLowercaseString(params.exclude_colors);
+    const normalizedColorIdentity = normalizeColorIdentity(params.color_identity);
 
     if (!normalizedFocusCard || typeof normalizedFocusCard !== 'string') {
       throw new ValidationError('Focus card is required and must be a string');
@@ -118,6 +129,10 @@ export class FindSynergisticCardsTool {
 
     if (normalizedExcludeColors && typeof normalizedExcludeColors !== 'string') {
       throw new ValidationError('Exclude colors must be a string');
+    }
+
+    if (params.color_identity !== undefined && !normalizedColorIdentity) {
+      throw new ValidationError('Color identity must include one or more Magic colors');
     }
 
     if (params.max_cmc !== undefined) {
@@ -144,12 +159,13 @@ export class FindSynergisticCardsTool {
     return {
       focus_card: normalizedFocusCard,
       synergy_type: typeof normalizedSynergyType === 'string' ? normalizedSynergyType : undefined,
-      format: typeof normalizedFormat === 'string' ? normalizedFormat : undefined,
+      format: typeof normalizedFormat === 'string' ? normalizedFormat as MagicFormat : undefined,
       exclude_colors: typeof normalizedExcludeColors === 'string' ? normalizedExcludeColors : undefined,
       max_cmc: params.max_cmc,
       include_lands: includeLands,
       limit,
-      arena_only: arenaOnly
+      arena_only: arenaOnly,
+      color_identity: normalizedColorIdentity
     };
   }
 
@@ -176,54 +192,39 @@ export class FindSynergisticCardsTool {
       );
 
       // Execute searches with multi-layered strategy
-      const allResults = await this.searchQueries(
+      const primarySearch = await this.searchQueries(
         queries,
         params.limit,
         index => this.getPrimaryLayer(index)
       );
+      const allResults = [...primarySearch.results];
+      let failedSearches = primarySearch.failedSearches;
 
       // If no results and theme-based, try broader searches
       if (allResults.length === 0 && !focusCard) {
-        // Build a basic query with just the format/constraints
-        let fallbackBaseQuery = '';
-        if (params.format) {
-          fallbackBaseQuery += `legal:${params.format} `;
-        }
-        if (params.exclude_colors) {
-          for (const color of params.exclude_colors.toLowerCase()) {
-            if ('wubrg'.includes(color)) {
-              fallbackBaseQuery += `-c:${color} `;
-            }
-          }
-        }
-        if (params.max_cmc !== undefined) {
-          fallbackBaseQuery += `cmc<=${params.max_cmc} `;
-        }
-        if (!params.include_lands) {
-          fallbackBaseQuery += '-t:land ';
-        }
-        if (params.arena_only) {
-          fallbackBaseQuery += 'game:arena ';
-        }
-
+        const fallbackBaseQuery = buildBaseQuery(params);
         const fallbackQueries = this.prioritizeQueries(
           getFallbackQueries(params.focus_card, fallbackBaseQuery),
           MAX_FALLBACK_QUERY_CANDIDATES
         );
-        const fallbackResults = await this.searchQueries(
+        const fallbackSearch = await this.searchQueries(
           fallbackQueries,
           params.limit,
           () => 'thematic',
           1
         );
-        allResults.push(...fallbackResults);
+        allResults.push(...fallbackSearch.results);
+        failedSearches += fallbackSearch.failedSearches;
       }
 
       // Remove duplicates and filter results with layered prioritization
       const uniqueResults = filterAndDeduplicateResults(allResults, focusCard, params.focus_card);
+      const resultConstraints = this.getResultConstraints(params, focusCard);
+      const constrainedResults = uniqueResults.filter(card => this.matchesResultConstraints(card, resultConstraints));
+      const filteredResultCount = uniqueResults.length - constrainedResults.length;
 
       // Prioritize results by synergy layer (semantic > exact > thematic)
-      const prioritizedResults = prioritizeResultsByLayer(uniqueResults);
+      const prioritizedResults = prioritizeResultsByLayer(constrainedResults);
 
       // Limit results
       const finalResults = prioritizedResults.slice(0, params.limit);
@@ -249,6 +250,14 @@ export class FindSynergisticCardsTool {
           data: finalResults
         };
         responseText += formatResultsWithSynergyExplanations(mockSearchResponse, focusCard, params.focus_card);
+      }
+
+      if (failedSearches > 0) {
+        responseText += `\n\n⚠️ Some Scryfall searches failed (${failedSearches}). Results shown are partial.`;
+      }
+
+      if (filteredResultCount > 0) {
+        responseText += `\n\nFiltered ${filteredResultCount} cards that did not match legality, Arena, or color-identity constraints.`;
       }
 
       return {
@@ -308,9 +317,10 @@ export class FindSynergisticCardsTool {
     targetUniqueResults: number,
     getLayer: (index: number) => SynergyLayer,
     stopAfterUniqueResults = targetUniqueResults
-  ): Promise<SynergyCard[]> {
+  ): Promise<{ results: SynergyCard[]; failedSearches: number }> {
     const allResults: SynergyCard[] = [];
     const uniqueResultIds = new Set<string>();
+    let failedSearches = 0;
 
     for (const [index, query] of queries.entries()) {
       if (uniqueResultIds.size >= stopAfterUniqueResults) {
@@ -331,10 +341,11 @@ export class FindSynergisticCardsTool {
 
         const layer = getLayer(index);
         for (const card of results.data) {
-          if (!uniqueResultIds.has(card.id)) {
-            uniqueResultIds.add(card.id);
+          if (uniqueResultIds.has(card.id)) {
+            continue;
           }
 
+          uniqueResultIds.add(card.id);
           allResults.push({
             ...card,
             _synergy_layer: layer,
@@ -342,11 +353,15 @@ export class FindSynergisticCardsTool {
           });
         }
       } catch {
+        failedSearches += 1;
         continue;
       }
     }
 
-    return allResults;
+    return {
+      results: allResults,
+      failedSearches
+    };
   }
 
   private getPerQueryLimit(
@@ -360,5 +375,45 @@ export class FindSynergisticCardsTool {
 
     const remaining = Math.max(0, targetUniqueResults - currentUniqueResults);
     return Math.min(Math.max(5, remaining + 4), targetUniqueResults + 5);
+  }
+
+  private getResultConstraints(
+    params: ValidatedSynergyParams,
+    focusCard: ScryfallCard | null
+  ): {
+    format?: MagicFormat;
+    arenaOnly: boolean;
+    colorIdentity?: string;
+  } {
+    return {
+      format: params.format,
+      arenaOnly: params.arena_only,
+      colorIdentity: params.color_identity ?? normalizeColorIdentity((focusCard?.color_identity || []).join('')),
+    };
+  }
+
+  private matchesResultConstraints(
+    card: SynergyCard,
+    constraints: { format?: MagicFormat; arenaOnly: boolean; colorIdentity?: string }
+  ): boolean {
+    if (constraints.format && card.legalities?.[constraints.format] !== 'legal') {
+      return false;
+    }
+
+    if (constraints.arenaOnly && !card.games?.includes('arena')) {
+      return false;
+    }
+
+    if (constraints.colorIdentity) {
+      const allowed = new Set(constraints.colorIdentity.split(''));
+      const cardIdentity = normalizeColorIdentity((card.color_identity || []).join('')) ?? '';
+      for (const color of cardIdentity) {
+        if (!allowed.has(color)) {
+          return false;
+        }
+      }
+    }
+
+    return true;
   }
 }

--- a/src/tools/find-synergistic-cards/query-builder.ts
+++ b/src/tools/find-synergistic-cards/query-builder.ts
@@ -1,5 +1,5 @@
 import { ScryfallCard } from '../../types/scryfall-api.js';
-import { SynergyCard, SynergyParams } from './types.js';
+import { SynergyParams } from './types.js';
 
 function extractCreatureTypes(typeLine: string): string[] {
   const commonTypes = [
@@ -116,6 +116,75 @@ function getColorName(colorCode: string): string {
   };
 
   return colorMap[colorCode.toUpperCase()] || colorCode;
+}
+
+export function normalizeColorIdentity(value: string | undefined): string | undefined {
+  if (!value?.trim()) {
+    return undefined;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  const namedIdentities: Record<string, string> = {
+    white: 'w',
+    blue: 'u',
+    black: 'b',
+    red: 'r',
+    green: 'g',
+    azorius: 'wu',
+    dimir: 'ub',
+    rakdos: 'br',
+    gruul: 'rg',
+    selesnya: 'gw',
+    orzhov: 'wb',
+    izzet: 'ur',
+    golgari: 'bg',
+    boros: 'rw',
+    simic: 'gu',
+    esper: 'wub',
+    grixis: 'ubr',
+    jund: 'brg',
+    naya: 'rgw',
+    bant: 'gwu',
+    abzan: 'wbg',
+    jeskai: 'urw',
+    sultai: 'bgu',
+    mardu: 'rwb',
+    temur: 'gur',
+  };
+
+  const colors = new Set<string>();
+  const words = normalized.split(/[^a-z]+/).filter(Boolean);
+  for (const word of words) {
+    const named = namedIdentities[word];
+    if (named) {
+      for (const color of named) {
+        colors.add(color);
+      }
+      continue;
+    }
+
+    if (/^[wubrg]+$/.test(word)) {
+      for (const color of word) {
+        colors.add(color);
+      }
+    }
+  }
+
+  if (colors.size === 0 && /^[wubrg\s,]+$/i.test(value)) {
+    for (const color of normalized) {
+      if ('wubrg'.includes(color)) {
+        colors.add(color);
+      }
+    }
+  }
+
+  return colors.size > 0
+    ? [...colors].sort((a, b) => 'wubrg'.indexOf(a) - 'wubrg'.indexOf(b)).join('')
+    : undefined;
+}
+
+function getCardColorIdentity(card: ScryfallCard): string | undefined {
+  return normalizeColorIdentity((card.color_identity || []).join(''));
 }
 
 function getSemanticSynergies(focusCard: ScryfallCard, baseQuery: string): string[] {
@@ -314,16 +383,9 @@ function getArchetypeSynergies(focusCard: ScryfallCard, baseQuery: string): stri
 }
 
 function buildOracleBaseQuery(card: ScryfallCard, baseQuery: string): string {
-  const colorIdentity = [...(card.color_identity || [])]
-    .map(color => color.toLowerCase())
-    .sort((a, b) => 'wubrg'.indexOf(a) - 'wubrg'.indexOf(b))
-    .join('');
   const trimmedBaseQuery = baseQuery.trim();
 
-  return [
-    trimmedBaseQuery,
-    colorIdentity ? `ci<=${colorIdentity}` : ''
-  ].filter(Boolean).join(' ');
+  return trimmedBaseQuery;
 }
 
 function buildOracleDerivedQueries(card: ScryfallCard, baseQuery: string): string[] {
@@ -354,36 +416,51 @@ function buildOracleDerivedQueries(card: ScryfallCard, baseQuery: string): strin
   return queries;
 }
 
-export function buildSynergyQueries(
-  focusCard: ScryfallCard | null,
-  params: Omit<SynergyParams, 'limit'>
-): string[] {
-  const queries: string[] = [];
-  let baseQuery = '';
+export function buildBaseQuery(params: Omit<SynergyParams, 'limit'>): string {
+  const queryParts: string[] = [];
 
   if (params.format) {
-    baseQuery += `legal:${params.format} `;
+    queryParts.push(`legal:${params.format}`);
   }
 
   if (params.exclude_colors) {
     for (const color of params.exclude_colors.toLowerCase()) {
       if ('wubrg'.includes(color)) {
-        baseQuery += `-c:${color} `;
+        queryParts.push(`-c:${color}`);
       }
     }
   }
 
   if (params.max_cmc !== undefined) {
-    baseQuery += `cmc<=${params.max_cmc} `;
+    queryParts.push(`cmc<=${params.max_cmc}`);
   }
 
   if (!params.include_lands) {
-    baseQuery += '-t:land ';
+    queryParts.push('-t:land');
   }
 
   if (params.arena_only) {
-    baseQuery += 'game:arena ';
+    queryParts.push('game:arena');
   }
+
+  const colorIdentity = normalizeColorIdentity(params.color_identity);
+  if (colorIdentity) {
+    queryParts.push(`ci<=${colorIdentity}`);
+  }
+
+  return queryParts.length > 0 ? `${queryParts.join(' ')} ` : '';
+}
+
+export function buildSynergyQueries(
+  focusCard: ScryfallCard | null,
+  params: Omit<SynergyParams, 'limit'>
+): string[] {
+  const queries: string[] = [];
+  const effectiveParams = {
+    ...params,
+    color_identity: params.color_identity ?? (focusCard ? getCardColorIdentity(focusCard) : undefined),
+  };
+  const baseQuery = buildBaseQuery(effectiveParams);
 
   if (focusCard) {
     queries.push(...getCardBasedSynergies(focusCard, baseQuery, params.synergy_type, params.focus_card));

--- a/src/tools/find-synergistic-cards/query-builder.ts
+++ b/src/tools/find-synergistic-cards/query-builder.ts
@@ -313,6 +313,47 @@ function getArchetypeSynergies(focusCard: ScryfallCard, baseQuery: string): stri
   return queries;
 }
 
+function buildOracleBaseQuery(card: ScryfallCard, baseQuery: string): string {
+  const colorIdentity = [...(card.color_identity || [])]
+    .map(color => color.toLowerCase())
+    .sort((a, b) => 'wubrg'.indexOf(a) - 'wubrg'.indexOf(b))
+    .join('');
+  const trimmedBaseQuery = baseQuery.trim();
+
+  return [
+    trimmedBaseQuery,
+    colorIdentity ? `ci<=${colorIdentity}` : ''
+  ].filter(Boolean).join(' ');
+}
+
+function buildOracleDerivedQueries(card: ScryfallCard, baseQuery: string): string[] {
+  const oracle = card.oracle_text?.toLowerCase() ?? '';
+  const typeLine = card.type_line?.toLowerCase() ?? '';
+  const queryBase = buildOracleBaseQuery(card, baseQuery);
+  const prefix = queryBase ? `${queryBase} ` : '';
+  const queries: string[] = [];
+
+  if (oracle.includes('instant or sorcery')) {
+    queries.push(`${prefix}o:"instant or sorcery"`);
+    queries.push(`${prefix}(t:instant or t:sorcery)`);
+  }
+
+  if (oracle.includes('treasure')) {
+    queries.push(`${prefix}o:Treasure`);
+  }
+
+  if (typeLine.includes('goblin')) {
+    queries.push(`${prefix}t:goblin`);
+  }
+
+  if (typeLine.includes('wizard') || typeLine.includes('sorcerer')) {
+    queries.push(`${prefix}t:wizard`);
+    queries.push(`${prefix}(t:wizard or t:sorcerer or t:warlock or t:shaman)`);
+  }
+
+  return queries;
+}
+
 export function buildSynergyQueries(
   focusCard: ScryfallCard | null,
   params: Omit<SynergyParams, 'limit'>
@@ -346,6 +387,7 @@ export function buildSynergyQueries(
 
   if (focusCard) {
     queries.push(...getCardBasedSynergies(focusCard, baseQuery, params.synergy_type, params.focus_card));
+    queries.push(...buildOracleDerivedQueries(focusCard, baseQuery));
   } else {
     queries.push(...getThemeBasedSynergies(params.focus_card, baseQuery, params.synergy_type));
   }

--- a/src/tools/find-synergistic-cards/types.ts
+++ b/src/tools/find-synergistic-cards/types.ts
@@ -9,6 +9,7 @@ export interface FindSynergisticCardsInput {
   include_lands?: boolean;
   limit?: number;
   arena_only?: boolean;
+  color_identity?: string;
 }
 
 export interface SynergyParams {
@@ -20,6 +21,7 @@ export interface SynergyParams {
   include_lands: boolean;
   limit: number;
   arena_only: boolean;
+  color_identity?: string;
 }
 
 export type SynergyLayer = 'semantic' | 'exact' | 'thematic';

--- a/src/tools/search-cards.ts
+++ b/src/tools/search-cards.ts
@@ -9,6 +9,10 @@ import { formatSearchResultsAsText, formatSearchResultsAsJson } from "../utils/f
 import { ScryfallAPIError, ValidationError, SearchCardsParams, RateLimitError } from "../types/mcp-types.js";
 import { generateRequestId } from "../types/mcp-errors.js";
 
+function hasArenaGameFilter(query: string): boolean {
+  return /\bgame\s*:\s*arena\b/i.test(query);
+}
+
 /**
  * MCP Tool for searching Magic: The Gathering cards using Scryfall syntax
  */
@@ -156,7 +160,7 @@ export class SearchCardsTool {
 
       // Build final query with Arena filtering if requested
       let finalQuery = sanitizedQuery;
-      if (params.arena_only) {
+      if (params.arena_only && !hasArenaGameFilter(sanitizedQuery)) {
         const arenaModification = sanitizeQueryModification(" game:arena");
         finalQuery = `${finalQuery} ${arenaModification}`;
       }

--- a/src/tools/suggest-mana-base.ts
+++ b/src/tools/suggest-mana-base.ts
@@ -1,4 +1,3 @@
-import { ScryfallClient } from '../services/scryfall-client.js';
 import { ValidationError } from '../types/mcp-types.js';
 import { formatManaBaseResponse } from './suggest-mana-base/formatter.js';
 import {
@@ -83,8 +82,8 @@ export class SuggestManaBaseTool {
     required: ['color_requirements']
   };
 
-  constructor(_scryfallClient: ScryfallClient) {
-    void _scryfallClient;
+  constructor(_unused?: unknown) {
+    void _unused;
   }
 
   private validateParams(args: unknown): ManaBaseParams {
@@ -111,9 +110,32 @@ export class SuggestManaBaseTool {
       }
     }
 
-    const deckSize = params.deck_size || 60;
+    const deckSize = params.deck_size ?? 60;
     if (typeof deckSize !== 'number' || deckSize < 40 || deckSize > 250) {
       throw new ValidationError('Deck size must be between 40 and 250');
+    }
+
+    if (params.average_cmc !== undefined) {
+      if (typeof params.average_cmc !== 'number' || params.average_cmc < 0 || params.average_cmc > 10) {
+        throw new ValidationError('Average CMC must be between 0 and 10');
+      }
+    }
+
+    if (params.color_intensity !== undefined) {
+      if (!params.color_intensity || typeof params.color_intensity !== 'object' || Array.isArray(params.color_intensity)) {
+        throw new ValidationError('Color intensity must be an object');
+      }
+
+      const validIntensityColors = new Set(['W', 'U', 'B', 'R', 'G']);
+      for (const [color, value] of Object.entries(params.color_intensity)) {
+        if (!validIntensityColors.has(color)) {
+          throw new ValidationError(`Invalid color intensity key: ${color}`);
+        }
+
+        if (typeof value !== 'number' || value < 0 || value > 10) {
+          throw new ValidationError(`Color intensity for ${color} must be between 0 and 10`);
+        }
+      }
     }
 
     const strategy = (typeof normalizedStrategy === 'string' ? normalizedStrategy : undefined) || 'midrange';

--- a/src/tools/suggest-mana-base/planner.ts
+++ b/src/tools/suggest-mana-base/planner.ts
@@ -113,7 +113,7 @@ export function calculateColorDistribution(
     assignedSlots += allocation.base;
   }
 
-  let remainingSlots = availableSlots - assignedSlots;
+  const remainingSlots = availableSlots - assignedSlots;
   exactAllocations
     .sort((a, b) => b.fraction - a.fraction)
     .slice(0, remainingSlots)

--- a/src/tools/suggest-mana-base/planner.ts
+++ b/src/tools/suggest-mana-base/planner.ts
@@ -65,9 +65,9 @@ export function calculateLandCount(params: ManaBaseParams): number {
     }
   }
 
-  if (params.format === 'commander') {
+  if (params.format === 'commander' || (params.format === 'brawl' && deck_size >= 90)) {
     baseCount = Math.max(36, Math.min(40, baseCount));
-  } else if (params.format === 'brawl') {
+  } else if (params.format === 'brawl' || params.format === 'standardbrawl') {
     baseCount = Math.max(22, Math.min(26, baseCount));
   }
 

--- a/src/types/mcp-types.ts
+++ b/src/types/mcp-types.ts
@@ -276,6 +276,9 @@ export interface FormattedCard {
   power?: string;
   toughness?: string;
   set_name: string;
+  set: string;
+  collector_number: string;
+  arena_id?: number;
   rarity: string;
   prices: {
     usd?: string;

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -8,6 +8,7 @@ export function formatCard(card: ScryfallCard, includeImage = true): FormattedCa
   // Handle multi-faced cards
   const mainFace = card.card_faces?.[0] || card;
   const name = card.card_faces ? `${card.card_faces[0].name} // ${card.card_faces[1].name}` : card.name;
+  const arenaId = (card as ScryfallCard & { arena_id?: number }).arena_id;
   
   return {
     name,
@@ -17,6 +18,9 @@ export function formatCard(card: ScryfallCard, includeImage = true): FormattedCa
     power: mainFace.power || card.power,
     toughness: mainFace.toughness || card.toughness,
     set_name: card.set_name,
+    set: card.set,
+    collector_number: card.collector_number,
+    arena_id: arenaId,
     rarity: card.rarity,
     prices: {
       usd: card.prices.usd,

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -8,6 +8,10 @@ import {
   BuildQueryParamsSchema,
   ValidationError,
 } from "../types/mcp-types.js";
+import {
+  validateScryfallQuery as validateScryfallQueryCore,
+  type ValidationResult as QueryValidationResult,
+} from "./query-validator.js";
 
 /**
  * Validates search cards parameters
@@ -132,95 +136,15 @@ export function validateBuildQueryParams(params: unknown) {
   }
 }
 
-/**
- * Result interface for query validation
- */
-export interface ValidationResult {
-  isValid: boolean;
-  errors: Array<{ message: string; position?: number }>;
-  warnings: Array<{ message: string; position?: number }>;
-  suggestions?: string[];
+export type ValidationResult = QueryValidationResult;
+
+export function validateScryfallQuerySync(query: string): ValidationResult {
+  return validateScryfallQueryCore(query);
 }
 
-/**
- * Enhanced Scryfall query validation with detailed feedback
- */
 export function validateScryfallQuery(query: string): Promise<ValidationResult> {
   return Promise.resolve(validateScryfallQuerySync(query));
 }
-
-/**
- * Synchronous Scryfall query validation with comprehensive checks
- */
-export function validateScryfallQuerySync(query: string): ValidationResult {
-  const result: ValidationResult = {
-    isValid: true,
-    errors: [],
-    warnings: [],
-    suggestions: []
-  };
-
-  if (!query || query.trim().length === 0) {
-    result.isValid = false;
-    result.errors.push({ message: "Search query cannot be empty" });
-    return result;
-  }
-
-  const trimmedQuery = query.trim();
-
-  // Check for basic syntax errors
-  const openParens = (trimmedQuery.match(/\(/g) || []).length;
-  const closeParens = (trimmedQuery.match(/\)/g) || []).length;
-
-  if (openParens !== closeParens) {
-    result.isValid = false;
-    result.errors.push({ message: "Unmatched parentheses in search query" });
-  }
-
-  // Check for invalid operators at the start
-  if (/^(AND|OR|NOT)\s/i.test(trimmedQuery)) {
-    result.isValid = false;
-    result.errors.push({ message: "Search query cannot start with a boolean operator" });
-  }
-
-  // Check for consecutive operators
-  if (/\b(AND|OR|NOT)\s+(AND|OR|NOT)\b/i.test(trimmedQuery)) {
-    result.isValid = false;
-    result.errors.push({ message: "Consecutive boolean operators are not allowed" });
-  }
-
-  // Check for common issues and provide warnings
-  if (/[<>]=?/.test(trimmedQuery) && !/\b(cmc|pow|tou|loy)\b/.test(trimmedQuery)) {
-    result.warnings.push({ 
-      message: "Comparison operators should typically be used with numeric fields like cmc, pow, tou, or loy" 
-    });
-  }
-
-  // Check for potentially misspelled operators
-  if (/\bcolou?r\b/i.test(trimmedQuery)) {
-    result.warnings.push({ 
-      message: "Use 'c:' or 'color:' instead of 'color' for color searches" 
-    });
-    result.suggestions?.push("Try 'c:red' instead of 'color red'");
-  }
-
-  // Check for excessive complexity
-  const operatorCount = (trimmedQuery.match(/\b(AND|OR|NOT)\b/gi) || []).length;
-  if (operatorCount > 10) {
-    result.warnings.push({ 
-      message: "Query is very complex and may be slow to execute" 
-    });
-  }
-
-  // Add helpful suggestions for common patterns
-  if (result.errors.length === 0 && trimmedQuery.split(/\s+/).length > 5 && !/[:()"']/.test(trimmedQuery)) {
-    result.suggestions?.push("Consider using operators like 'c:', 't:', or 'o:' for more precise searches");
-  }
-
-  return result;
-}
-
-// ValidationResult type is already exported above
 
 /**
  * Validates card identifier format

--- a/tests/analyze-deck-composition-parser.test.ts
+++ b/tests/analyze-deck-composition-parser.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { AnalyzeDeckCompositionTool, parseDeckListEntries } from '../src/tools/analyze-deck-composition.js';
+import { RateLimitError, ScryfallAPIError } from '../src/types/mcp-types.js';
 
 const islandCard = {
   id: 'island',
@@ -54,5 +55,81 @@ describe('AnalyzeDeckCompositionTool Brawl land recommendations', () => {
     expect(result.content[0].text).toContain('Total Cards: 100');
     expect(result.content[0].text).toContain('lands: 38');
     expect(result.content[0].text).not.toContain('Consider reducing lands');
+  });
+
+  it('uses exact card lookup before fuzzy fallback for parsed deck names', async () => {
+    const calls: Array<{ identifier: string; match?: string }> = [];
+    const client = {
+      getCard: async ({ identifier, match }: { identifier: string; match?: string }) => {
+        calls.push({ identifier, match });
+
+        if (identifier === 'Lightning Bolt' && match === 'exact') {
+          throw new ScryfallAPIError('Not found', 404);
+        }
+
+        return {
+          ...optCard,
+          name: identifier === 'Lightning Bolt' ? 'Lightning Bolt' : identifier,
+        };
+      },
+    };
+    const tool = new AnalyzeDeckCompositionTool(client as never);
+
+    const result = await tool.execute({
+      deck_list: '1 Lightning Bolt',
+      format: 'brawl',
+      strategy: 'combo',
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(calls).toEqual([
+      { identifier: 'Lightning Bolt', match: 'exact' },
+      { identifier: 'Lightning Bolt', match: undefined },
+    ]);
+    expect(result.content[0].text).toContain('Fuzzy name resolutions');
+    expect(result.content[0].text).toContain('Lightning Bolt -> Lightning Bolt');
+  });
+
+  it('returns an explicit rate-limit message when no deck cards can be fetched', async () => {
+    const client = {
+      getCard: async () => {
+        throw new RateLimitError('Rate limit exceeded', 60);
+      },
+    };
+    const tool = new AnalyzeDeckCompositionTool(client as never);
+
+    const result = await tool.execute({
+      deck_list: '1 Opt',
+      format: 'brawl',
+      strategy: 'combo',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe('Rate limit exceeded. Retry after 60s. No deck analysis was produced.');
+  });
+
+  it('returns a partial analysis warning when rate limiting interrupts deck fetches', async () => {
+    const client = {
+      getCard: async ({ identifier }: { identifier: string }) => {
+        if (identifier === 'Opt') {
+          throw new RateLimitError('Rate limit exceeded', 30);
+        }
+
+        return islandCard;
+      },
+    };
+    const tool = new AnalyzeDeckCompositionTool(client as never);
+
+    const result = await tool.execute({
+      deck_list: '1 Island\n1 Opt',
+      format: 'brawl',
+      strategy: 'combo',
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain('Partial analysis');
+    expect(result.content[0].text).toContain('Retry after 30s');
+    expect(result.content[0].text).toContain('1 card name was not analyzed');
+    expect(result.content[0].text).toContain('Total Cards: 2');
   });
 });

--- a/tests/analyze-deck-composition-parser.test.ts
+++ b/tests/analyze-deck-composition-parser.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { AnalyzeDeckCompositionTool, parseDeckListEntries } from '../src/tools/analyze-deck-composition.js';
+
+const islandCard = {
+  id: 'island',
+  name: 'Island',
+  cmc: 0,
+  type_line: 'Basic Land - Island',
+  prices: { usd: '0.01' },
+  rarity: 'common',
+  color_identity: [],
+};
+
+const optCard = {
+  id: 'opt',
+  name: 'Opt',
+  cmc: 1,
+  type_line: 'Instant',
+  prices: { usd: '0.05' },
+  rarity: 'common',
+  color_identity: ['U'],
+};
+
+describe('parseDeckListEntries', () => {
+  it('preserves commas inside card names', () => {
+    expect(parseDeckListEntries('1 Baral, Chief of Compliance\n1 Ral, Storm Conduit')).toEqual([
+      { name: 'Baral, Chief of Compliance', quantity: 1 },
+      { name: 'Ral, Storm Conduit', quantity: 1 },
+    ]);
+  });
+
+  it('strips Arena set and collector suffixes', () => {
+    expect(parseDeckListEntries('Commander\n1 Sanar, Unfinished Genius (SOS) 223\n\nDeck\n5 Island (SOS) 274')).toEqual([
+      { name: 'Sanar, Unfinished Genius', quantity: 1 },
+      { name: 'Island', quantity: 5 },
+    ]);
+  });
+});
+
+describe('AnalyzeDeckCompositionTool Brawl land recommendations', () => {
+  it('does not recommend reducing realistic 100-card Brawl land counts', async () => {
+    const client = {
+      getCard: async ({ identifier }: { identifier: string }) => identifier === 'Island' ? islandCard : optCard,
+    };
+    const tool = new AnalyzeDeckCompositionTool(client as never);
+
+    const result = await tool.execute({
+      deck_list: '38 Island\n62 Opt',
+      format: 'brawl',
+      strategy: 'combo',
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain('Total Cards: 100');
+    expect(result.content[0].text).toContain('lands: 38');
+    expect(result.content[0].text).not.toContain('Consider reducing lands');
+  });
+});

--- a/tests/batch-card-analysis.test.ts
+++ b/tests/batch-card-analysis.test.ts
@@ -4,7 +4,7 @@ import { analyzeLegality, analyzePrices } from '../src/tools/batch-card-analysis
 import { ScryfallAPIError } from '../src/types/mcp-types.js';
 
 describe('fetchCardsWithConcurrency', () => {
-  it('limits in-flight card fetches to the configured concurrency', async () => {
+  it('limits helper-level scheduled fetches to the configured concurrency for injected clients', async () => {
     let inFlight = 0;
     let maxInFlight = 0;
 

--- a/tests/cache-service.test.ts
+++ b/tests/cache-service.test.ts
@@ -101,7 +101,7 @@ describe("CacheService", () => {
     expect(cache.getStats().memoryUsage).toBeGreaterThan(0);
   });
 
-  it("selects eviction victims with at most one least-recently-used scan", () => {
+  it("selects eviction victims via iterative least-recently-used scans", () => {
     const cache = new CacheService(60_000, 10, 1);
     caches.push(cache);
 
@@ -121,7 +121,8 @@ describe("CacheService", () => {
 
     expect(cache.get("large")).toBe("large".repeat(60_000));
     expect(cache.get("c")).toBe("c".repeat(150_000));
-    expect(findSpy.mock.calls.length).toBeLessThanOrEqual(1);
+    expect(findSpy.mock.calls.length).toBeGreaterThan(0);
+    expect(findSpy.mock.calls.length).toBeLessThanOrEqual(3);
   });
 
   it("estimates object size without invoking toJSON when no size hint is provided", () => {
@@ -141,5 +142,21 @@ describe("CacheService", () => {
 
     expect(serializeCount).toBe(0);
     expect(cache.getStats().memoryUsage).toBeGreaterThan(0);
+  });
+
+  it("does not cache entries larger than maxMemoryBytes and leaves memory accounting unchanged", () => {
+    const cache = new CacheService(60_000, 100, 1);
+    caches.push(cache);
+
+    cache.set("small", "s".repeat(100_000), 60_000);
+    const beforeOversized = cache.getStats();
+    expect(cache.get("small")).toBe("s".repeat(100_000));
+
+    cache.set("oversized", "o".repeat(700_000), 60_000);
+
+    const afterOversized = cache.getStats();
+    expect(cache.get("oversized")).toBeNull();
+    expect(afterOversized.size).toBe(beforeOversized.size);
+    expect(afterOversized.memoryUsage).toBe(beforeOversized.memoryUsage);
   });
 });

--- a/tests/card-database-resource.test.ts
+++ b/tests/card-database-resource.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CardDatabaseResource } from "../src/resources/card-database.js";
 import { CacheService } from "../src/services/cache-service.js";
+import { mcpLogger } from "../src/services/logger.js";
 import { BulkDataInfo, ScryfallCard } from "../src/types/scryfall-api.js";
 
 function createMockCard(overrides: Partial<ScryfallCard> = {}): ScryfallCard {
@@ -220,17 +221,88 @@ describe("CardDatabaseResource", () => {
     expect(parsed.data[0].name).toBe("Lightning Bolt");
   });
 
-  it("reports builder diagnostics after rebuilding the serialized snapshot", async () => {
+  it("reports builder diagnostics after rebuilding and caching the serialized snapshot", async () => {
     await resource.getData();
 
     const diagnostics = (
       resource as unknown as {
-        getLastBuildDiagnostics: () => { totalCards: number; retainedChunks: number };
+        getLastBuildDiagnostics: () => {
+          totalCards: number;
+          retainedChunks: number;
+          payloadBytes: number;
+          cached: boolean;
+          oversizeReason?: string;
+        };
       }
     ).getLastBuildDiagnostics();
 
     expect(diagnostics.totalCards).toBe(mockCards.length);
     expect(diagnostics.retainedChunks).toBeLessThanOrEqual(mockCards.length);
+    expect(diagnostics.payloadBytes).toBeGreaterThan(0);
+    expect(diagnostics.cached).toBe(true);
+    expect(diagnostics.oversizeReason).toBeUndefined();
+  });
+
+  it("reports oversized snapshots that cannot be retained in the in-memory cache", async () => {
+    cache.destroy();
+    cache = new CacheService(60_000, 100, 0.0001);
+    resource = new CardDatabaseResource(
+      {
+        getBulkDataInfo,
+        streamBulkData,
+      } as never,
+      cache
+    );
+    const warnSpy = vi.spyOn(mcpLogger, "warn").mockImplementation(() => undefined);
+
+    const payload = await resource.getData();
+
+    expect(JSON.parse(payload).total_cards).toBe(mockCards.length);
+    expect(cache.get<string>(CacheService.createBulkKey("cards:serialized"))).toBeNull();
+
+    const diagnostics = (
+      resource as unknown as {
+        getLastBuildDiagnostics: () => {
+          totalCards: number;
+          retainedChunks: number;
+          payloadBytes: number;
+          cached: boolean;
+          oversizeReason?: string;
+        };
+      }
+    ).getLastBuildDiagnostics();
+
+    expect(diagnostics.totalCards).toBe(mockCards.length);
+    expect(diagnostics.payloadBytes).toBeGreaterThan(cache.getStats().maxMemoryBytes);
+    expect(diagnostics.cached).toBe(false);
+    expect(diagnostics.oversizeReason).toContain("exceeds cache memory limit");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operation: "bulk_snapshot_cache",
+        payloadBytes: diagnostics.payloadBytes,
+      }),
+      "Bulk snapshot exceeds in-memory cache limit"
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it("exposes bulk cache retention diagnostics in resource metadata", async () => {
+    await resource.getData();
+
+    const metadata = resource.getMetadata() as {
+      last_build: {
+        totalCards: number;
+        payloadBytes: number;
+        cached: boolean;
+      };
+      cache_ttl_remaining: number | null;
+    };
+
+    expect(metadata.last_build.totalCards).toBe(mockCards.length);
+    expect(metadata.last_build.payloadBytes).toBeGreaterThan(0);
+    expect(metadata.last_build.cached).toBe(true);
+    expect(metadata.cache_ttl_remaining).toBeGreaterThan(0);
   });
 
   it("forceRefresh clears the cached snapshot and rebuilds it", async () => {

--- a/tests/find-synergistic-cards.test.ts
+++ b/tests/find-synergistic-cards.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { FindSynergisticCardsTool } from "../src/tools/find-synergistic-cards.js";
+import { buildSynergyQueries } from "../src/tools/find-synergistic-cards/query-builder.js";
 import { formatResultsWithSynergyExplanations } from "../src/tools/find-synergistic-cards/result-formatter.js";
 import { ScryfallAPIError } from "../src/types/mcp-types.js";
 import type { SynergyCard } from "../src/tools/find-synergistic-cards/types.js";
+import type { ScryfallCard } from "../src/types/scryfall-api.js";
 
 function createCard(id: string, layer?: SynergyCard["_synergy_layer"]): SynergyCard {
   return {
@@ -78,6 +80,38 @@ function createCard(id: string, layer?: SynergyCard["_synergy_layer"]): SynergyC
     _synergy_layer: layer,
   };
 }
+
+function makeCard(overrides: Partial<ScryfallCard>): ScryfallCard {
+  return {
+    ...createCard("focus"),
+    related_uris: {},
+    ...overrides,
+  };
+}
+
+describe("buildSynergyQueries", () => {
+  it("builds Sanar-style fallback queries from oracle text and creature types", () => {
+    const params = {
+      focus_card: "Sanar, Unfinished Genius",
+      synergy_type: "theme",
+      format: "brawl",
+      include_lands: true,
+      limit: 20,
+      arena_only: true,
+    };
+    const queries = buildSynergyQueries(makeCard({
+      name: "Sanar, Unfinished Genius // Wild Idea",
+      type_line: "Legendary Creature — Goblin Sorcerer",
+      oracle_text: "Sanar enters prepared.\n{T}: Create a Treasure token. Activate only if you've cast an instant or sorcery spell this turn.",
+      color_identity: ["U", "R"],
+    }), params);
+
+    expect(queries).toContain('legal:brawl game:arena ci<=ur o:"instant or sorcery"');
+    expect(queries).toContain('legal:brawl game:arena ci<=ur o:Treasure');
+    expect(queries).toContain('legal:brawl game:arena ci<=ur t:goblin');
+    expect(queries).toContain('legal:brawl game:arena ci<=ur t:wizard');
+  });
+});
 
 describe("FindSynergisticCardsTool", () => {
   it("uses a larger first-query budget because synergy searches are serialized", () => {

--- a/tests/find-synergistic-cards.test.ts
+++ b/tests/find-synergistic-cards.test.ts
@@ -6,7 +6,11 @@ import { ScryfallAPIError } from "../src/types/mcp-types.js";
 import type { SynergyCard } from "../src/tools/find-synergistic-cards/types.js";
 import type { ScryfallCard } from "../src/types/scryfall-api.js";
 
-function createCard(id: string, layer?: SynergyCard["_synergy_layer"]): SynergyCard {
+function createCard(
+  id: string,
+  layer?: SynergyCard["_synergy_layer"],
+  overrides: Partial<SynergyCard> = {}
+): SynergyCard {
   return {
     object: "card",
     id,
@@ -78,6 +82,7 @@ function createCard(id: string, layer?: SynergyCard["_synergy_layer"]): SynergyC
     story_spotlight: false,
     prices: {},
     _synergy_layer: layer,
+    ...overrides,
   };
 }
 
@@ -110,10 +115,37 @@ describe("buildSynergyQueries", () => {
     expect(queries).toContain('legal:brawl game:arena ci<=ur o:Treasure');
     expect(queries).toContain('legal:brawl game:arena ci<=ur t:goblin');
     expect(queries).toContain('legal:brawl game:arena ci<=ur t:wizard');
+    expect(queries.every(query => query.includes('ci<=ur'))).toBe(true);
+  });
+
+  it("applies explicit color identity constraints to theme-only synergy queries", () => {
+    const params = {
+      focus_card: "instant sorcery treasure",
+      synergy_type: "theme",
+      format: "brawl",
+      include_lands: false,
+      limit: 20,
+      arena_only: true,
+      color_identity: "UR",
+    };
+
+    const queries = buildSynergyQueries(null, params);
+
+    expect(queries.length).toBeGreaterThan(0);
+    expect(queries.every(query => query.startsWith('legal:brawl -t:land game:arena ci<=ur '))).toBe(true);
   });
 });
 
 describe("FindSynergisticCardsTool", () => {
+  it("deduplicates and caps query candidates before execution", () => {
+    const tool = new FindSynergisticCardsTool({} as never);
+    const prioritizeQueries = (tool as unknown as {
+      prioritizeQueries: (queries: string[], maxQueries: number) => string[];
+    }).prioritizeQueries.bind(tool);
+
+    expect(prioritizeQueries([" q:a ", "q:a", "q:b", "q:c"], 2)).toEqual(["q:a", "q:b"]);
+  });
+
   it("uses a larger first-query budget because synergy searches are serialized", () => {
     const tool = new FindSynergisticCardsTool({} as never);
 
@@ -158,6 +190,117 @@ describe("FindSynergisticCardsTool", () => {
     await tool.execute({ focus_card: "artifact token theme", limit: 2 });
 
     expect(searchCards).toHaveBeenCalledTimes(1);
+  });
+
+  it("adds a partial-failure note when some search queries fail", async () => {
+    const searchCards = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("temporary outage"))
+      .mockResolvedValue({
+        object: "list",
+        total_cards: 1,
+        has_more: false,
+        data: [createCard("ok-card")],
+      });
+
+    const tool = new FindSynergisticCardsTool({
+      getCard: vi.fn().mockRejectedValue(new ScryfallAPIError("not found", 404, "not_found")),
+      searchCards,
+    } as never);
+
+    const result = await tool.execute({ focus_card: "artifact token theme", limit: 2 });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain("Some Scryfall searches failed");
+  });
+
+  it("does not emit duplicate cards when multiple queries return the same card id", async () => {
+    const duplicateCard = createCard("same-id");
+    const searchCards = vi
+      .fn()
+      .mockResolvedValueOnce({
+        object: "list",
+        total_cards: 1,
+        has_more: false,
+        data: [duplicateCard],
+      })
+      .mockResolvedValueOnce({
+        object: "list",
+        total_cards: 1,
+        has_more: false,
+        data: [duplicateCard],
+      })
+      .mockResolvedValue({
+        object: "list",
+        total_cards: 0,
+        has_more: false,
+        data: [],
+      });
+
+    const tool = new FindSynergisticCardsTool({
+      getCard: vi.fn().mockRejectedValue(new ScryfallAPIError("not found", 404, "not_found")),
+      searchCards,
+    } as never);
+
+    const result = await tool.execute({ focus_card: "artifact token theme", limit: 3 });
+    const duplicateMentions = (result.content[0].text.match(/Card SAME-ID/g) || []).length;
+    expect(result.isError).toBeUndefined();
+    expect(duplicateMentions).toBe(1);
+  });
+
+  it("filters off-color, non-Arena, and format-illegal synergy results before formatting", async () => {
+    const allowed = createCard("allowed", "semantic", {
+      name: "Allowed Izzet Card",
+      color_identity: ["U", "R"],
+      games: ["arena"],
+    });
+    const offColor = createCard("off-color", "semantic", {
+      name: "Off Color Card",
+      color_identity: ["B"],
+      games: ["arena"],
+    });
+    const nonArena = createCard("non-arena", "semantic", {
+      name: "Non Arena Card",
+      color_identity: ["U"],
+      games: ["paper"],
+    });
+    const illegal = createCard("illegal", "semantic", {
+      name: "Illegal Card",
+      color_identity: ["R"],
+      games: ["arena"],
+      legalities: {
+        ...createCard("legality-source").legalities,
+        brawl: "not_legal",
+      },
+    });
+    const searchCards = vi.fn().mockResolvedValueOnce({
+      object: "list",
+      total_cards: 4,
+      has_more: false,
+      data: [allowed, offColor, nonArena, illegal],
+    });
+
+    const tool = new FindSynergisticCardsTool({
+      getCard: vi.fn().mockRejectedValue(new ScryfallAPIError("not found", 404, "not_found")),
+      searchCards,
+    } as never);
+
+    const result = await tool.execute({
+      focus_card: "instant sorcery treasure",
+      format: "brawl",
+      arena_only: true,
+      color_identity: "UR",
+      limit: 5,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain("Allowed Izzet Card");
+    expect(result.content[0].text).not.toContain("Off Color Card");
+    expect(result.content[0].text).not.toContain("Non Arena Card");
+    expect(result.content[0].text).not.toContain("Illegal Card");
+    expect(result.content[0].text).toContain(
+      "Filtered 3 cards that did not match legality, Arena, or color-identity constraints."
+    );
   });
 });
 

--- a/tests/http-smoke-script.test.ts
+++ b/tests/http-smoke-script.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+describe('HTTP smoke SSE parser', () => {
+  it('parses the expected Streamable HTTP SSE message frame', async () => {
+    const { parseSseMessage } = await import('../scripts/http-mcp-smoke-lib.mjs');
+
+    expect(parseSseMessage('event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{"ok":true}}\n\n')).toEqual({
+      jsonrpc: '2.0',
+      id: 1,
+      result: { ok: true },
+    });
+  });
+
+  it('rejects malformed SSE frames without a message event', async () => {
+    const { parseSseMessage } = await import('../scripts/http-mcp-smoke-lib.mjs');
+
+    expect(() => parseSseMessage('data: {"jsonrpc":"2.0"}\n\n')).toThrow(
+      'Expected SSE event "message", got none'
+    );
+  });
+});

--- a/tests/query-builder.test.ts
+++ b/tests/query-builder.test.ts
@@ -55,14 +55,14 @@ describe('Natural-Language Query Builder', () => {
 
       const query = buildBaseQuery(mappings);
 
-      expect(query).toContain('c:=u');
+      expect(query).toContain('c:u');
       expect(query).toContain('(t:instant OR t:sorcery)');
-      expect(query).toContain('usd:<=5');
-      expect(query).toContain('pow:>=2');
+      expect(query).toContain('usd<=5');
+      expect(query).toContain('pow>=2');
     });
 
     it('adds format restrictions without disturbing the existing query', () => {
-      expect(applyFormat('t:artifact usd:<=5', 'commander')).toBe('t:artifact usd:<=5 f:commander');
+      expect(applyFormat('t:artifact usd<=5', 'commander')).toBe('t:artifact usd<=5 f:commander');
       expect(applyFormat('', 'modern')).toBe('f:modern');
     });
   });
@@ -99,7 +99,7 @@ describe('Natural-Language Query Builder', () => {
       );
 
       expect(broadened.query).toContain('cmc<=4');
-      expect(broadened.query).toContain('usd:<=10');
+      expect(broadened.query).toContain('usd<=10');
       expect(broadened.optimizations[0]?.type).toBe('broadening');
 
       expect(narrowed.query).toContain('f:modern');
@@ -165,7 +165,7 @@ describe('Natural-Language Query Builder', () => {
       });
 
       expect(result.query).toContain('f:modern');
-      expect(result.query).toContain('usd:<=10');
+      expect(result.query).toContain('usd<=10');
       expect(result.query).toContain('c:>=u');
       expect(result.query).toContain('instant OR sorcery');
       expect(result.optimizations.some((optimization) => optimization.type === 'broadening')).toBe(true);
@@ -197,7 +197,7 @@ describe('Natural-Language Query Builder', () => {
 
       expect(result.query).toContain('t:artifact');
       expect(result.query).toContain('f:commander');
-      expect(result.query).toContain('usd:<=10');
+      expect(result.query).toContain('usd<=10');
       expect(result.optimizations.some((optimization) => optimization.type === 'narrowing')).toBe(true);
       expect(result.testSummary).toEqual({ total_cards: 350, has_more: false });
       expect(result.explanation).toContain('artifact cards');

--- a/tests/rate-limiter-429.test.ts
+++ b/tests/rate-limiter-429.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+import { RateLimiter } from "../src/services/rate-limiter.js";
+
+describe("RateLimiter 429 handling", () => {
+  it("does not open the circuit after one retry-after response", async () => {
+    vi.useFakeTimers();
+    try {
+      const limiter = new RateLimiter(100, 3, 2, 1_000);
+      const waiting = limiter.handleRateLimitResponse("1");
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await waiting;
+
+      expect(limiter.isCircuitOpen()).toBe(false);
+      expect(limiter.getStatus().consecutiveErrors).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/rate-limiter-429.test.ts
+++ b/tests/rate-limiter-429.test.ts
@@ -2,17 +2,95 @@ import { describe, expect, it, vi } from "vitest";
 import { RateLimiter } from "../src/services/rate-limiter.js";
 
 describe("RateLimiter 429 handling", () => {
-  it("does not open the circuit after one retry-after response", async () => {
+  it("records retry-after as the next request window without sleeping immediately", async () => {
     vi.useFakeTimers();
     try {
       const limiter = new RateLimiter(100, 3, 2, 1_000);
-      const waiting = limiter.handleRateLimitResponse("1");
+      const baseTime = Date.now();
+      const startedAt: number[] = [];
 
-      await vi.advanceTimersByTimeAsync(1_000);
-      await waiting;
+      const first = limiter.execute(async () => {
+        startedAt.push(Date.now() - baseTime);
+        limiter.recordError(429);
+        limiter.handleRateLimitResponse("1");
+        return "rate-limited";
+      });
+
+      const second = limiter.execute(async () => {
+        startedAt.push(Date.now() - baseTime);
+        return "next";
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+      await expect(first).resolves.toBe("rate-limited");
+      expect(startedAt).toEqual([0]);
+
+      await vi.advanceTimersByTimeAsync(999);
+      expect(startedAt).toEqual([0]);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(second).resolves.toBe("next");
+      expect(startedAt).toEqual([0, 1_000]);
 
       expect(limiter.isCircuitOpen()).toBe(false);
       expect(limiter.getStatus().consecutiveErrors).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("uses configured backoff once when a 429 has no retry-after header", async () => {
+    vi.useFakeTimers();
+    try {
+      const limiter = new RateLimiter(100, 3, 2, 1_000);
+      const baseTime = Date.now();
+      const startedAt: number[] = [];
+
+      const first = limiter.execute(async () => {
+        startedAt.push(Date.now() - baseTime);
+        limiter.recordError(429);
+        limiter.handleRateLimitResponse();
+        return "rate-limited";
+      });
+
+      const second = limiter.execute(async () => {
+        startedAt.push(Date.now() - baseTime);
+        return "next";
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+      await expect(first).resolves.toBe("rate-limited");
+
+      await vi.advanceTimersByTimeAsync(199);
+      expect(startedAt).toEqual([0]);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(second).resolves.toBe("next");
+      expect(startedAt).toEqual([0, 200]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears pending 429 throttle state on reset", async () => {
+    vi.useFakeTimers();
+    try {
+      const limiter = new RateLimiter(100, 3, 2, 1_000);
+      const baseTime = Date.now();
+      const startedAt: number[] = [];
+
+      limiter.recordError(429);
+      limiter.handleRateLimitResponse("5");
+      limiter.reset();
+
+      const afterReset = limiter.execute(async () => {
+        startedAt.push(Date.now() - baseTime);
+        return "after-reset";
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+      await expect(afterReset).resolves.toBe("after-reset");
+      expect(startedAt).toEqual([0]);
     } finally {
       vi.useRealTimers();
     }

--- a/tests/rate-limiter.test.ts
+++ b/tests/rate-limiter.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
 import { RateLimiter } from "../src/services/rate-limiter.js";
+import { RateLimitError } from "../src/types/mcp-types.js";
 
 describe("RateLimiter", () => {
   afterEach(() => {
@@ -63,5 +64,48 @@ describe("RateLimiter", () => {
     await vi.advanceTimersByTimeAsync(1);
     await expect(second).resolves.toBe("ok");
     expect(startedAt).toEqual([0, 20]);
+  });
+
+  it("rejects queued and sleeping operations when reset is called, then resumes safely", async () => {
+    vi.useFakeTimers();
+
+    const limiter = new RateLimiter(100, 3, 2, 1000);
+    const postResetStarted: string[] = [];
+    let releasePostResetFirst: (() => void) | undefined;
+
+    const first = limiter.execute(async () => "first");
+    const sleeping = limiter.execute(async () => "should-not-run");
+    const queued = limiter.execute(async () => "should-not-run");
+
+    await vi.advanceTimersByTimeAsync(0);
+    await expect(first).resolves.toBe("first");
+
+    limiter.reset();
+
+    await expect(sleeping).rejects.toBeInstanceOf(RateLimitError);
+    await expect(queued).rejects.toBeInstanceOf(RateLimitError);
+
+    const postResetFirst = limiter.execute(async () => {
+      postResetStarted.push("first");
+      await new Promise<void>((resolve) => {
+        releasePostResetFirst = resolve;
+      });
+      return "post-reset-first";
+    });
+
+    const postResetSecond = limiter.execute(async () => {
+      postResetStarted.push("second");
+      return "post-reset-second";
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(postResetStarted).toEqual(["first"]);
+
+    releasePostResetFirst?.();
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(postResetFirst).resolves.toBe("post-reset-first");
+    await expect(postResetSecond).resolves.toBe("post-reset-second");
+    expect(postResetStarted).toEqual(["first", "second"]);
   });
 });

--- a/tests/rate-limiter.test.ts
+++ b/tests/rate-limiter.test.ts
@@ -57,11 +57,11 @@ describe("RateLimiter", () => {
     await expect(first).resolves.toBe("failed");
     expect(startedAt).toEqual([0]);
 
-    await vi.advanceTimersByTimeAsync(39);
+    await vi.advanceTimersByTimeAsync(19);
     expect(startedAt).toEqual([0]);
 
     await vi.advanceTimersByTimeAsync(1);
     await expect(second).resolves.toBe("ok");
-    expect(startedAt).toEqual([0, 40]);
+    expect(startedAt).toEqual([0, 20]);
   });
 });

--- a/tests/scryfall-client-json.test.ts
+++ b/tests/scryfall-client-json.test.ts
@@ -150,6 +150,60 @@ describe("ScryfallClient JSON parsing", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("uses fuzzy card lookup by default", async () => {
+    fetchMock.mockResolvedValue({
+      status: 200,
+      ok: true,
+      headers: new Headers(),
+      json: vi.fn().mockResolvedValue(createCard()),
+    });
+
+    const client = createClient();
+
+    await client.getCard({ identifier: "Lightning Bolt" });
+
+    const url = new URL(fetchMock.mock.calls[0][0].toString());
+    expect(url.pathname).toBe("/cards/named");
+    expect(url.searchParams.get("fuzzy")).toBe("Lightning Bolt");
+    expect(url.searchParams.has("exact")).toBe(false);
+  });
+
+  it("uses exact card lookup when requested", async () => {
+    fetchMock.mockResolvedValue({
+      status: 200,
+      ok: true,
+      headers: new Headers(),
+      json: vi.fn().mockResolvedValue(createCard()),
+    });
+
+    const client = createClient();
+
+    await client.getCard({ identifier: "Lightning Bolt", match: "exact" });
+
+    const url = new URL(fetchMock.mock.calls[0][0].toString());
+    expect(url.pathname).toBe("/cards/named");
+    expect(url.searchParams.get("exact")).toBe("Lightning Bolt");
+    expect(url.searchParams.has("fuzzy")).toBe(false);
+  });
+
+  it("does not reuse cached card details across exact and fuzzy lookup modes", async () => {
+    fetchMock.mockResolvedValue({
+      status: 200,
+      ok: true,
+      headers: new Headers(),
+      json: vi.fn().mockResolvedValue(createCard()),
+    });
+
+    const client = createClient();
+
+    await client.getCard({ identifier: "Lightning Bolt", match: "exact" });
+    await client.getCard({ identifier: "Lightning Bolt" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(new URL(fetchMock.mock.calls[0][0].toString()).searchParams.has("exact")).toBe(true);
+    expect(new URL(fetchMock.mock.calls[1][0].toString()).searchParams.has("fuzzy")).toBe(true);
+  });
+
   it("coalesces concurrent equivalent card lookups", async () => {
     fetchMock.mockResolvedValue({
       status: 200,
@@ -166,5 +220,82 @@ describe("ScryfallClient JSON parsing", () => {
     ]);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps in-flight exact and fuzzy card lookups distinct", async () => {
+    fetchMock.mockResolvedValue({
+      status: 200,
+      ok: true,
+      headers: new Headers(),
+      json: vi.fn().mockResolvedValue(createCard()),
+    });
+
+    const client = createClient();
+
+    await Promise.all([
+      client.getCard({ identifier: "Lightning Bolt", match: "exact" }),
+      client.getCard({ identifier: "Lightning Bolt" }),
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    [404, "not_found"],
+    [422, "invalid_query"],
+  ])("does not count expected HTTP %s responses as transient failures", async (status, code) => {
+    fetchMock.mockResolvedValue({
+      status,
+      ok: false,
+      headers: new Headers(),
+      json: vi.fn().mockResolvedValue({
+        object: "error",
+        code,
+        details: "User-correctable request error",
+      }),
+    });
+
+    const client = createClient();
+
+    await expect(client.searchCards({ query: "type:creature", limit: 1 })).rejects.toThrow(
+      "User-correctable request error"
+    );
+    expect(rateLimiter.recordError).not.toHaveBeenCalled();
+    expect(rateLimiter.handleRateLimitResponse).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [429, "rate_limited"],
+    [500, "server_error"],
+  ])("counts transient HTTP %s responses as service failures", async (status, code) => {
+    fetchMock.mockResolvedValue({
+      status,
+      ok: false,
+      headers: new Headers(status === 429 ? { "retry-after": "1" } : undefined),
+      json: vi.fn().mockResolvedValue({
+        object: "error",
+        code,
+        details: "Transient Scryfall failure",
+      }),
+    });
+
+    const client = createClient();
+
+    await expect(client.searchCards({ query: "type:creature", limit: 1 })).rejects.toThrow();
+    expect(rateLimiter.recordError).toHaveBeenCalledWith(status);
+    if (status === 429) {
+      expect(rateLimiter.handleRateLimitResponse).toHaveBeenCalledWith("1");
+    }
+  });
+
+  it("counts network failures as transient failures", async () => {
+    fetchMock.mockRejectedValue(new Error("socket closed"));
+
+    const client = createClient();
+
+    await expect(client.searchCards({ query: "type:creature", limit: 1 })).rejects.toThrow(
+      "Network error: socket closed"
+    );
+    expect(rateLimiter.recordError).toHaveBeenCalledWith();
   });
 });

--- a/tests/search-pagination.test.ts
+++ b/tests/search-pagination.test.ts
@@ -203,4 +203,84 @@ describe("ScryfallClient search pagination", () => {
       "second page warning",
     ]);
   });
+
+  it("does not reuse cached search results across different sort orders", async () => {
+    fetchMock
+      .mockResolvedValueOnce(createFetchResponse(createSearchResponse(0, 1, 2)))
+      .mockResolvedValueOnce(createFetchResponse(createSearchResponse(100, 1, 2)));
+
+    const client = new ScryfallClient(
+      {
+        execute: vi.fn(async (operation: () => Promise<unknown>) => operation()),
+        waitForClearance: vi.fn().mockResolvedValue(undefined),
+        recordSuccess: vi.fn(),
+        recordError: vi.fn(),
+        handleRateLimitResponse: vi.fn(),
+        isCircuitOpen: vi.fn().mockReturnValue(false),
+      } as never,
+      cache
+    );
+
+    const byName = await client.searchCards({ query: "type:creature", limit: 1, order: "name" });
+    const byReleased = await client.searchCards({ query: "type:creature", limit: 1, order: "released" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0].toString()).toContain("order=name");
+    expect(fetchMock.mock.calls[1][0].toString()).toContain("order=released");
+    expect(byName.data[0].name).toBe("Card 0");
+    expect(byReleased.data[0].name).toBe("Card 100");
+  });
+
+  it("does not reuse cached search results across include_extras changes", async () => {
+    fetchMock
+      .mockResolvedValueOnce(createFetchResponse(createSearchResponse(0, 1, 2)))
+      .mockResolvedValueOnce(createFetchResponse(createSearchResponse(200, 1, 2)));
+
+    const client = new ScryfallClient(
+      {
+        execute: vi.fn(async (operation: () => Promise<unknown>) => operation()),
+        waitForClearance: vi.fn().mockResolvedValue(undefined),
+        recordSuccess: vi.fn(),
+        recordError: vi.fn(),
+        handleRateLimitResponse: vi.fn(),
+        isCircuitOpen: vi.fn().mockReturnValue(false),
+      } as never,
+      cache
+    );
+
+    const withoutExtras = await client.searchCards({ query: "type:creature", limit: 1 });
+    const withExtras = await client.searchCards({ query: "type:creature", limit: 1, include_extras: true });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0].toString()).not.toContain("include_extras=true");
+    expect(fetchMock.mock.calls[1][0].toString()).toContain("include_extras=true");
+    expect(withoutExtras.data[0].name).toBe("Card 0");
+    expect(withExtras.data[0].name).toBe("Card 200");
+  });
+
+  it("uses the final price-filtered query as the search cache identity", async () => {
+    fetchMock.mockResolvedValue(createFetchResponse(createSearchResponse(0, 1, 2)));
+
+    const client = new ScryfallClient(
+      {
+        execute: vi.fn(async (operation: () => Promise<unknown>) => operation()),
+        waitForClearance: vi.fn().mockResolvedValue(undefined),
+        recordSuccess: vi.fn(),
+        recordError: vi.fn(),
+        handleRateLimitResponse: vi.fn(),
+        isCircuitOpen: vi.fn().mockReturnValue(false),
+      } as never,
+      cache
+    );
+
+    await client.searchCards({
+      query: "type:creature",
+      limit: 1,
+      price_range: { max: 5, currency: "usd" },
+    });
+    await client.searchCards({ query: "type:creature usd<=5", limit: 1 });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0].toString()).toContain("type%3Acreature+usd%3C%3D5");
+  });
 });

--- a/tests/server-smoke.test.ts
+++ b/tests/server-smoke.test.ts
@@ -95,6 +95,55 @@ describe('MCP server smoke tests', () => {
     );
   });
 
+  it('continues serving valid search calls after a user-correctable invalid search', async () => {
+    const invalidResult = await invokeRequest(sdkServer, 'tools/call', {
+      name: 'search_cards',
+      arguments: {
+        query: '(c:red AND t:creature',
+      },
+    });
+
+    expect((invalidResult as { isError?: boolean }).isError).toBe(true);
+    expect(mockScryfallClient.searchCards).not.toHaveBeenCalled();
+
+    mockScryfallClient.searchCards.mockResolvedValue({
+      total_cards: 1,
+      has_more: false,
+      data: [
+        {
+          id: 'bolt-id',
+          name: 'Lightning Bolt',
+          mana_cost: '{R}',
+          type_line: 'Instant',
+          oracle_text: 'Lightning Bolt deals 3 damage to any target.',
+          set_name: 'Magic 2010',
+          rarity: 'common',
+          prices: { usd: '1.00' },
+          legalities: { modern: 'legal' },
+        },
+      ],
+    });
+
+    const validResult = await invokeRequest(sdkServer, 'tools/call', {
+      name: 'search_cards',
+      arguments: {
+        query: 'Lightning Bolt',
+        order: 'name',
+        limit: 1,
+      },
+    });
+
+    const response = validResult as { content: Array<{ text: string }>; isError?: boolean };
+    expect(response.isError).toBeUndefined();
+    expect(response.content[0].text).toContain('Lightning Bolt');
+    expect(mockScryfallClient.searchCards).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: 'Lightning Bolt',
+        order: 'name',
+      })
+    );
+  });
+
   it('executes the rules lookup tool through the server layer', async () => {
     const result = await invokeRequest(sdkServer, 'tools/call', {
       name: 'query_rules',

--- a/tests/suggest-mana-base-brawl.test.ts
+++ b/tests/suggest-mana-base-brawl.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { calculateLandCount } from '../src/tools/suggest-mana-base/planner.js';
+
+describe('calculateLandCount for Brawl', () => {
+  it('recommends Commander-like land counts for 100-card Historic Brawl', () => {
+    expect(calculateLandCount({
+      color_requirements: 'UR',
+      deck_size: 100,
+      format: 'brawl',
+      strategy: 'combo',
+      average_cmc: 2.7,
+      budget: 'no_limit',
+      special_requirements: [],
+    })).toBe(38);
+  });
+
+  it('keeps Standard Brawl near 24 lands for 60-card decks', () => {
+    expect(calculateLandCount({
+      color_requirements: 'UR',
+      deck_size: 60,
+      format: 'standardbrawl',
+      strategy: 'midrange',
+      average_cmc: 3,
+      budget: 'moderate',
+      special_requirements: [],
+    })).toBe(24);
+  });
+});

--- a/tests/suggest-mana-base-brawl.test.ts
+++ b/tests/suggest-mana-base-brawl.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { calculateLandCount } from '../src/tools/suggest-mana-base/planner.js';
+import { SuggestManaBaseTool } from '../src/tools/suggest-mana-base.js';
 
 describe('calculateLandCount for Brawl', () => {
   it('recommends Commander-like land counts for 100-card Historic Brawl', () => {
@@ -24,5 +25,39 @@ describe('calculateLandCount for Brawl', () => {
       budget: 'moderate',
       special_requirements: [],
     })).toBe(24);
+  });
+});
+
+describe('SuggestManaBaseTool validation', () => {
+  const tool = new SuggestManaBaseTool();
+
+  it('rejects deck_size of 0 instead of falling back to default', async () => {
+    const result = await tool.execute({
+      color_requirements: 'WU',
+      deck_size: 0
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Deck size must be between 40 and 250');
+  });
+
+  it('rejects average_cmc values outside schema bounds', async () => {
+    const result = await tool.execute({
+      color_requirements: 'WU',
+      average_cmc: 11
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Average CMC must be between 0 and 10');
+  });
+
+  it('rejects out-of-range color_intensity values', async () => {
+    const result = await tool.execute({
+      color_requirements: 'WU',
+      color_intensity: { W: 11 }
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Color intensity for W must be between 0 and 10');
   });
 });

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -248,6 +248,44 @@ describe('MCP Tools', () => {
         query: 'game:arena legal:brawl t:goblin'
       }));
     });
+
+    it('returns a validation error for invalid query syntax before calling search', async () => {
+      const result = await tool.execute({ query: '(c:red AND t:creature' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Validation error');
+      expect(result.content[0].text.toLowerCase()).toContain('unbalanced parentheses');
+      expect(mockScryfallClient.searchCards).not.toHaveBeenCalled();
+    });
+
+    it('continues search when validator emits warnings without hard errors', async () => {
+      mockScryfallClient.searchCards.mockResolvedValue({
+        object: 'list',
+        total_cards: 1,
+        has_more: false,
+        data: [{
+          id: 'warn-path-id',
+          name: 'Lightning Bolt',
+          mana_cost: '{R}',
+          type_line: 'Instant',
+          oracle_text: 'Lightning Bolt deals 3 damage to any target.',
+          set_name: 'Alpha',
+          set: 'lea',
+          collector_number: '161',
+          rarity: 'common',
+          prices: { usd: '1.00' },
+          legalities: { modern: 'legal' }
+        }]
+      });
+
+      const result = await tool.execute({ query: 'colr:red t:instant' });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('Lightning Bolt');
+      expect(mockScryfallClient.searchCards).toHaveBeenCalledWith(expect.objectContaining({
+        query: 'colr:red t:instant'
+      }));
+    });
   });
 
   describe('BuildScryfallQueryTool', () => {
@@ -1025,6 +1063,10 @@ describe('MCP Tools', () => {
       tool = new AnalyzeDeckCompositionTool(mockScryfallClient);
     });
 
+    it('should not expose commander as a public input parameter', () => {
+      expect(tool.inputSchema.properties.commander).toBeUndefined();
+    });
+
     it('should respect quantities in the deck list', async () => {
       mockScryfallClient.getCard.mockImplementation(async ({ identifier }: { identifier: string }) => {
         if (identifier === 'Lightning Bolt') {
@@ -1124,8 +1166,8 @@ describe('MCP Tools', () => {
 
       await Promise.resolve();
       expect(mockScryfallClient.getCard).toHaveBeenCalledTimes(2);
-      expect(mockScryfallClient.getCard).toHaveBeenNthCalledWith(1, { identifier: 'Lightning Bolt' });
-      expect(mockScryfallClient.getCard).toHaveBeenNthCalledWith(2, { identifier: 'Mountain' });
+      expect(mockScryfallClient.getCard).toHaveBeenNthCalledWith(1, { identifier: 'Lightning Bolt', match: 'exact' });
+      expect(mockScryfallClient.getCard).toHaveBeenNthCalledWith(2, { identifier: 'Mountain', match: 'exact' });
 
       mountainLookup.resolve({
         id: 'mountain-id',
@@ -1222,7 +1264,7 @@ describe('MCP Tools', () => {
     let tool: SuggestManaBaseTool;
 
     beforeEach(() => {
-      tool = new SuggestManaBaseTool(mockScryfallClient);
+      tool = new SuggestManaBaseTool();
     });
 
     it('should not recommend more lands than the computed land count', async () => {

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -181,6 +181,9 @@ describe('MCP Tools', () => {
           type_line: 'Instant',
           oracle_text: 'Lightning Bolt deals 3 damage to any target.',
           set_name: 'Alpha',
+          set: 'lea',
+          collector_number: '161',
+          arena_id: 67330,
           rarity: 'common',
           prices: { usd: '1.00' },
           legalities: { modern: 'legal' }
@@ -204,7 +207,46 @@ describe('MCP Tools', () => {
         order: 'usd',
         price_range: { min: 0.5, max: 2.0, currency: 'usd' }
       }));
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.cards[0]).toMatchObject({
+        name: 'Lightning Bolt',
+        set: 'lea',
+        collector_number: '161',
+        arena_id: 67330
+      });
       expect(result.content[0].text.trim().startsWith('{')).toBe(true);
+    });
+
+    it('does not append duplicate game:arena when arena_only is true', async () => {
+      mockScryfallClient.searchCards.mockResolvedValue({
+        object: 'list',
+        total_cards: 1,
+        has_more: false,
+        data: [{
+          id: 'test-id',
+          name: 'Goblin Guide',
+          mana_cost: '{R}',
+          type_line: 'Creature — Goblin Scout',
+          oracle_text: 'Haste',
+          set_name: 'Zendikar',
+          set: 'zen',
+          collector_number: '126',
+          rarity: 'rare',
+          prices: { usd: '5.00' },
+          legalities: { brawl: 'legal' }
+        }]
+      });
+
+      const result = await tool.execute({
+        query: 'game:arena legal:brawl t:goblin',
+        arena_only: true,
+        format: 'json'
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(mockScryfallClient.searchCards).toHaveBeenCalledWith(expect.objectContaining({
+        query: 'game:arena legal:brawl t:goblin'
+      }));
     });
   });
 

--- a/tests/utils/query-validator.test.ts
+++ b/tests/utils/query-validator.test.ts
@@ -4,6 +4,7 @@ import {
   validateScryfallQuerySync,
   validateScryfallQueryAsync,
 } from "../../src/utils/query-validator.js";
+import { validateScryfallQuery as validateScryfallQueryFromValidators } from "../../src/utils/validators.js";
 
 describe("Simple Query Validator", () => {
   describe("Basic Validation", () => {
@@ -200,6 +201,18 @@ describe("Simple Query Validator", () => {
       const result = await validateScryfallQueryAsync("");
       expect(result.isValid).toBe(false);
       expect(result.errors).toHaveLength(1);
+    });
+
+    it("uses the same implementation in validators.ts for search_cards integration", async () => {
+      const query = 'o:"draw a card" c:blue usd<=5';
+      const directResult = validateScryfallQuery(query);
+      const validatorsResult = await validateScryfallQueryFromValidators(query);
+
+      expect(validatorsResult).toEqual(directResult);
+      expect(validatorsResult).toHaveProperty("isValid");
+      expect(validatorsResult).toHaveProperty("errors");
+      expect(validatorsResult).toHaveProperty("warnings");
+      expect(validatorsResult).toHaveProperty("suggestions");
     });
   });
 


### PR DESCRIPTION
## Summary

- pace Scryfall 429 recovery in the shared rate limiter and tighten cache keys for search/card lookups
- add exact card lookup diagnostics for deck analysis and color-aware synergy filtering
- extend HTTP smoke coverage, Brawl mana-base tests, and deckbuilding artifacts

## Validation

- `npm run type-check`
- `npm test` (25 files, 280 tests)
- `git diff --check`
- `npm run smoke:http`

## Notes

The HTTP smoke path exercised `/health`, MCP initialize, `tools/list`, `validate_brawl_commander`, and `search_cards` against the local Streamable HTTP endpoint.